### PR TITLE
improvement(resource:compilation): start modules on freshly compiled drivers

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -46,7 +46,7 @@ shards:
 
   driver:
     github: placeos/driver
-    commit: 136ae2c8c11f817a37d25b28b1faca28f27cf33a
+    commit: 9327e72aa6bd784a1d85185c408bed18345a566f
 
   drivers:
     github: placeos/drivers
@@ -90,7 +90,7 @@ shards:
 
   models:
     github: placeos/models
-    commit: c88461cda10a2e06b7dfdb5cc040a12a749e11d4
+    commit: 2c69a77e712b03f7253b3b3a40948159e6c24b0b
 
   murmur3:
     github: aca-labs/murmur3


### PR DESCRIPTION
1. driver recompiled after commit change
1. associated modules (if any) are stopped
1. stale driver binary (if any) deleted
1. driver's modules restarted on the freshly compiled binary

I'm particularly aware of [allocating an array of Modules](https://github.com/PlaceOS/core/blob/reload-modules/src/core/compilation.cr#L85). Is it really necessary to stop the modules before deleting the binary?
