### PR TITLE
Start/Stop modules

### DIFF
--- a/spec/helper.cr
+++ b/spec/helper.cr
@@ -124,7 +124,10 @@ def setup(fresh : Bool = false)
     driver.repository = repository
     driver.save!
 
-    mod = PlaceOS::Model::Generator.module(driver: driver).save!
+    mod = PlaceOS::Model::Generator.module(driver: driver)
+    mod.running = true
+    mod.save!
+
     control_system = mod.control_system.as(PlaceOS::Model::ControlSystem)
     control_system.modules = [mod.id.as(String)]
     control_system.save!

--- a/src/core/compilation.cr
+++ b/src/core/compilation.cr
@@ -85,7 +85,7 @@ module PlaceOS
 
           # Remove the module running on the stale driver
           driver_path = module_manager.path_for?(module_id)
-          module_manager.remove_module(module_id)
+          module_manager.remove_module(mod)
 
           if module_manager.started?
             # Reload module on new driver binary


### PR DESCRIPTION
Update [`Core::ModuleManager`](https://github.com/PlaceOS/core/blob/fix/start-stop-modules/src/core/module_manager.cr) to respect `running` state on the node's initial Module load.
Includes some additional logging.

Fixes #3 