### PR TITLE
fix(log): bind to correct log namespace

### DIFF
--- a/src/app.cr
+++ b/src/app.cr
@@ -63,7 +63,7 @@ Signal::TERM.trap &terminate
 logging = Proc(Signal, Nil).new do |signal|
   level = signal.usr1? ? Log::Severity::Debug : Log::Severity::Info
   puts " > Log level changed to #{level}"
-  Log.builder.bind "core.*", level, PlaceOS::Core::LOG_BACKEND
+  Log.builder.bind "place_os.core.*", level, PlaceOS::Core::LOG_BACKEND
   signal.ignore
 end
 

--- a/src/config.cr
+++ b/src/config.cr
@@ -41,4 +41,4 @@ ActionController::Server.before(
 log_level = PlaceOS::Core.production? ? Log::Severity::Info : Log::Severity::Debug
 ::Log.setup "*", log_level, PlaceOS::Core::LOG_BACKEND
 ::Log.builder.bind "action-controller.*", log_level, PlaceOS::Core::LOG_BACKEND
-::Log.builder.bind "core.*", log_level, PlaceOS::Core::LOG_BACKEND
+::Log.builder.bind "place_os.core.*", log_level, PlaceOS::Core::LOG_BACKEND


### PR DESCRIPTION
`Log` was bound to `core` while the codebase was using `Log.for(self)` which produces the log namespace `place_os.core`