### PR TITLE
Support `TARGET` build-arg in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM crystallang/crystal:0.35.1-alpine as base
+# One of `core` | `edge`
+ARG TARGET=core
 
-# Set the commit through a build arg
-ARG PLACE_COMMIT="DEV"
-ARG TARGET="core"
+FROM crystallang/crystal:0.35.1-alpine as build
+
+ARG PLACE_COMMIT=DEV
+ARG TARGET
 
 WORKDIR /app
 
@@ -13,12 +15,9 @@ RUN apk add --no-cache libssh2 libssh2-dev iputils
 RUN apk update && apk add --no-cache ca-certificates tzdata && update-ca-certificates
 
 # Create a non-privileged user
-# defaults are appuser:10001
 ARG IMAGE_UID="10001"
 ENV UID=$IMAGE_UID
 ENV USER=appuser
-
-# See https://stackoverflow.com/a/55757473/12429735RUN
 RUN adduser \
     --disabled-password \
     --gecos "" \
@@ -28,100 +27,73 @@ RUN adduser \
     --uid "${UID}" \
     "${USER}"
 
+# Install deps
 COPY shard.yml /app
 COPY shard.lock /app
-RUN PLACE_COMMIT=$PLACE_COMMIT \
-    shards install --production
+RUN shards install --production
 
 # Add source last for efficient caching
 COPY src /app/src
 
-# Core
+# Build the required target
+RUN UNAME_AT_COMPILE_TIME=true \
+    PLACE_COMMIT=${PLACE_COMMIT} \
+    shards build ${TARGET} --production --static
+
 ###############################################################################
 
-FROM base AS build-core
-
-# Build Core
-RUN UNAME_AT_COMPILE_TIME=true \
-    PLACE_COMMIT=$PLACE_COMMIT \
-    crystal build --error-trace --debug -o bin/core src/core-app.cr
-    # crystal build --error-trace --release --debug -o bin/core src/core-app.cr
-
-# Edge
-###############################################################################
-
-FROM base AS edge-base
-
-# Build Edge
-RUN UNAME_AT_COMPILE_TIME=true \
-    PLACE_COMMIT=$PLACE_COMMIT \
-    crystal build --error-trace /app/src/edge-app.cr -o /app/edge
-    # crystal build --release --error-trace /app/src/edge-app.cr -o /app/edge
-
-# Extract dependencies
-RUN ldd /app/edge | tr -s '[:blank:]' '\n' | grep '^/' | \
-    xargs -I % sh -c 'mkdir -p $(dirname deps%); cp % deps%;'
-
-FROM scratch as build-edge
-
-WORKDIR /
-ENV PATH=$PATH:/
-COPY --from=edge-base /app/deps /
-COPY --from=edge-base /app/edge /edge
+FROM scratch as minimal
 
 # These are required for communicating with external services
-COPY --from=edge-base /etc/hosts /etc/hosts
+COPY --from=build /etc/hosts /etc/hosts
 
 # These provide certificate chain validation where communicating with external services over TLS
-COPY --from=edge-base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 # This is required for Timezone support
-COPY --from=edge-base /usr/share/zoneinfo/ /usr/share/zoneinfo/
+COPY --from=build /usr/share/zoneinfo/ /usr/share/zoneinfo/
 
 # Copy the user information over
-COPY --from=edge-base /etc/passwd /etc/passwd
-COPY --from=edge-base /etc/group /etc/group
-
-# Common environment configuration
-###############################################################################
-
-FROM build-${TARGET} AS common
-
-# Create a non-privileged user
-# defaults are appuser:10001
-ARG IMAGE_UID="10001"
-ENV UID=$IMAGE_UID
-ENV USER=appuser
+COPY --from=build /etc/passwd /etc/passwd
+COPY --from=build /etc/group /etc/group
 
 # These provide certificate chain validation where communicating with external services over TLS
 ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 
-# Use an unprivileged user.
+# Service binary
+COPY --from=build /app/bin /bin
+
 USER appuser:appuser
 
-# Entrypoints and custom environment
+WORKDIR /app
+
 ###############################################################################
 
-FROM common as edge
+FROM minimal as edge
 
-CMD ["/edge"]
+CMD ["/bin/edge"]
 
-FROM common as core
+###############################################################################
 
-# Set up driver directory
-RUN mkdir -p /app/bin/drivers
+# FIXME: core currently has a number of dependandancies on the runtime for
+# retreiving repositories and compiling drivers. When the migrates into an
+# external service, this can base from `minimal` instead for cleaner images.
+FROM build as core
 
-# Create binary directories
-RUN mkdir -p /app/repositories /app/bin/drivers
+COPY --from=build /app/bin /bin
 
+WORKDIR /app
 RUN chown appuser -R /app
 
-# Run the app binding on port 3000
+USER appuser:appuser
+
+# Create binary directories
+RUN mkdir -p repositories bin/drivers
+
 EXPOSE 3000
 HEALTHCHECK CMD wget -qO- http://localhost:3000/api/core/v1
-CMD ["/app/bin/core", "-b", "0.0.0.0", "-p", "3000"]
+CMD ["/bin/core", "-b", "0.0.0.0", "-p", "3000"]
 
-# Final build artefact
 ###############################################################################
 
-FROM ${TARGET} as final
+FROM ${TARGET}


### PR DESCRIPTION
Provides support for building both `edge` and `core` outputs from single `Dockerfile`.

General neaten up the docker builds and adds support for specifying the build target. This works with the vanilla docker build, as well as buildkit. When using buildkit unused stages will be automatically skipped.