### PR TITLE
fix: preserve debug connections when reloading modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ COPY src /app/src
 # Build the required target
 RUN UNAME_AT_COMPILE_TIME=true \
     PLACE_COMMIT=${PLACE_COMMIT} \
-    shards build ${TARGET} --static --error-trace
+    shards build ${TARGET} --production --release --static --error-trace
 
 # Create binary directories
 RUN mkdir -p repositories bin/drivers

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN adduser \
 COPY shard.yml /app
 COPY shard.override.yml /app
 COPY shard.lock /app
-RUN shards install --production
+RUN shards install --production --release
 
 # Add source last for efficient caching
 COPY src /app/src
@@ -39,7 +39,7 @@ COPY src /app/src
 # Build the required target
 RUN UNAME_AT_COMPILE_TIME=true \
     PLACE_COMMIT=${PLACE_COMMIT} \
-    shards build ${TARGET} --release --production --static --error-trace
+    shards build ${TARGET} --static --error-trace
 
 # Create binary directories
 RUN mkdir -p repositories bin/drivers

--- a/shard.lock
+++ b/shard.lock
@@ -5,9 +5,9 @@ shards:
     git: https://github.com/Nephos/CrystalEmail.git
     version: 0.2.4
 
-  action-controller: # Overridden
+  action-controller:
     git: https://github.com/spider-gazelle/action-controller.git
-    version: 3.5.1
+    version: 3.5.2
 
   active-model:
     git: https://github.com/spider-gazelle/active-model.git
@@ -31,7 +31,7 @@ shards:
 
   connect-proxy:
     git: https://github.com/spider-gazelle/connect-proxy.git
-    version: 1.0.1
+    version: 1.2.0
 
   crc16:
     git: https://github.com/maiha/crc16.cr.git
@@ -51,7 +51,7 @@ shards:
 
   etcd:
     git: https://github.com/place-labs/crystal-etcd.git
-    version: 1.0.5
+    version: 1.0.6
 
   exec_from:
     git: https://github.com/place-labs/exec_from.git
@@ -67,7 +67,7 @@ shards:
 
   habitat:
     git: https://github.com/luckyframework/habitat.git
-    version: 0.4.4
+    version: 0.4.5
 
   hardware:
     git: https://github.com/crystal-community/hardware.git
@@ -99,7 +99,7 @@ shards:
 
   lucky_router:
     git: https://github.com/luckyframework/lucky_router.git
-    version: 0.4.0
+    version: 0.4.1
 
   murmur3:
     git: https://github.com/aca-labs/murmur3.git
@@ -117,13 +117,13 @@ shards:
     git: https://github.com/placeos/compiler.git
     version: 3.3.1
 
-  placeos-driver:
-    git: https://github.com/placeos/driver.git
-    version: 4.1.2
+  placeos-driver: # Overridden
+    git: https://github.com/PlaceOS/driver.git
+    version: 4.1.3+git.commit.152ddec9d65fbf3d3bf221fd54294b2e1944122e
 
   placeos-models:
     git: https://github.com/placeos/models.git
-    version: 4.10.2
+    version: 4.11.0
 
   placeos-resource:
     git: https://github.com/place-labs/resource.git

--- a/shard.lock
+++ b/shard.lock
@@ -123,7 +123,7 @@ shards:
 
   placeos-models:
     git: https://github.com/placeos/models.git
-    version: 4.11.0
+    version: 4.12.1
 
   placeos-resource:
     git: https://github.com/place-labs/resource.git

--- a/shard.lock
+++ b/shard.lock
@@ -51,7 +51,7 @@ shards:
 
   etcd:
     git: https://github.com/place-labs/crystal-etcd.git
-    version: 1.0.6
+    version: 1.0.7
 
   exec_from:
     git: https://github.com/place-labs/exec_from.git
@@ -117,9 +117,9 @@ shards:
     git: https://github.com/placeos/compiler.git
     version: 3.3.1
 
-  placeos-driver: # Overridden
-    git: https://github.com/PlaceOS/driver.git
-    version: 4.1.3+git.commit.152ddec9d65fbf3d3bf221fd54294b2e1944122e
+  placeos-driver:
+    git: https://github.com/placeos/driver.git
+    version: 4.2.0
 
   placeos-models:
     git: https://github.com/placeos/models.git

--- a/shard.override.yml
+++ b/shard.override.yml
@@ -1,6 +1,3 @@
 dependencies:
-  placeos-driver:
-    github: PlaceOS/driver
-    branch: feat/forward-debug-listeners
   retriable:
     github: Sija/retriable.cr

--- a/shard.override.yml
+++ b/shard.override.yml
@@ -1,6 +1,6 @@
 dependencies:
+  placeos-driver:
+    github: PlaceOS/driver
+    branch: feat/forward-debug-listeners
   retriable:
     github: Sija/retriable.cr
-  action-controller:
-    github: spider-gazelle/action-controller
-    version: 3.5.1

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-core
-version: 3.0.0
+version: 3.0.1
 crystal: ~> 0.35
 
 targets:

--- a/src/config.cr
+++ b/src/config.cr
@@ -43,3 +43,4 @@ log_level = PlaceOS::Core.production? ? Log::Severity::Info : Log::Severity::Deb
 ::Log.setup "*", log_level, PlaceOS::Core::LOG_BACKEND
 ::Log.builder.bind "action-controller.*", log_level, PlaceOS::Core::LOG_BACKEND
 ::Log.builder.bind "place_os.core.*", log_level, PlaceOS::Core::LOG_BACKEND
+::Log.builder.bind "etcd.*", Log::Severity::Warn, PlaceOS::Core::LOG_BACKEND

--- a/src/controllers/command.cr
+++ b/src/controllers/command.cr
@@ -53,9 +53,10 @@ module PlaceOS::Core::Api
 
       # Forward debug messages to the websocket
       module_manager.process_manager(module_id) do |manager|
-        manager.debug(module_id, &->(message : String) { socket.send(message) })
+        callback = ->(message : String) { socket.send(message); nil }
+        manager.debug(module_id, &callback)
         # Stop debugging when the socket closes
-        socket.on_close { manager.ignore(module_id) }
+        socket.on_close { manager.ignore(module_id, &callback) }
       end
     end
 

--- a/src/placeos-core/client.cr
+++ b/src/placeos-core/client.cr
@@ -60,11 +60,7 @@ module PlaceOS::Core
       @connection = HTTP::Client.new(host: @host, port: @port)
     end
 
-    @connection : HTTP::Client?
-
-    protected def connection
-      @connection.as(HTTP::Client)
-    end
+    protected getter! connection : HTTP::Client
 
     protected getter connection_lock : Mutex = Mutex.new
 

--- a/src/placeos-core/compilation.cr
+++ b/src/placeos-core/compilation.cr
@@ -141,8 +141,9 @@ module PlaceOS
       commit.try(&.upcase) == "HEAD"
     end
 
-    # Returns the stale driver path
+    # Stops modules on stale driver and starts them on the new driver
     #
+    # Returns the stale driver path
     protected def self.reload_modules(
       driver : Model::Driver,
       module_manager : ModuleManager

--- a/src/placeos-core/process_manager.cr
+++ b/src/placeos-core/process_manager.cr
@@ -5,6 +5,7 @@ require "./error"
 module PlaceOS::Core
   module ProcessManager
     alias Request = PlaceOS::Driver::Protocol::Request
+    alias DebugCallback = PlaceOS::Driver::Protocol::Management::DebugCallback
 
     macro included
       Log = ::Log.for(self)
@@ -18,15 +19,13 @@ module PlaceOS::Core
 
     abstract def stop(module_id : String)
 
-    abstract def debug(module_id : String, &on_message : String ->)
+    abstract def debug(module_id : String, &on_message : DebugCallback)
 
-    abstract def ignore(module_id : String, &on_message : String ->)
+    abstract def ignore(module_id : String, &on_message : DebugCallback)
+
+    abstract def ignore(module_id : String) : Array(DebugCallback)
 
     abstract def kill(driver_path : String)
-
-    def ignore(module_id : String)
-      ignore(module_id) { }
-    end
 
     # Execute a driver method on a module
     #

--- a/src/placeos-core/process_manager/edge.cr
+++ b/src/placeos-core/process_manager/edge.cr
@@ -221,10 +221,7 @@ module PlaceOS::Core
 
     def fetch_binary(driver_key : String) : Protocol::Message::BinaryBody
       path = File.join(PlaceOS::Compiler.bin_dir, driver_key)
-
-      binary = Edge.read_file?(path)
-
-      Protocol::Message::BinaryBody.new(success: !binary.nil?, key: driver_key, binary: binary)
+      Protocol::Message::BinaryBody.new(success: File.exists?(path), key: driver_key, path: path)
     end
 
     # Metadata
@@ -308,17 +305,6 @@ module PlaceOS::Core
 
     def self.path_to_key(driver_path : String)
       driver_path.lchop(PlaceOS::Compiler.bin_dir).lstrip('/')
-    end
-
-    def self.read_file?(path : String) : Bytes?
-      File.open(path) do |file|
-        memory = IO::Memory.new
-        IO.copy file, memory
-        memory.to_slice
-      end
-    rescue e
-      Log.error(exception: e) { "failed to read #{path} into slice" }
-      nil
     end
   end
 end

--- a/src/placeos-core/process_manager/local.cr
+++ b/src/placeos-core/process_manager/local.cr
@@ -70,18 +70,21 @@ module PlaceOS::Core
         false
       end
 
-      def debug(module_id : String, &on_message : String ->)
+      def debug(module_id : String, &on_message : DebugCallback)
         manager = protocol_manager_by_module?(module_id)
         raise ModuleError.new("No protocol manager for #{module_id}") if manager.nil?
 
         manager.debug(module_id, &on_message)
       end
 
-      def ignore(module_id : String, &on_message : String ->)
-        manager = protocol_manager_by_module?(module_id)
-        raise ModuleError.new("No protocol manager for #{module_id}") if manager.nil?
-
+      def ignore(module_id : String, &on_message : DebugCallback)
+        return if (manager = protocol_manager_by_module?(module_id)).nil?
         manager.ignore(module_id, &on_message)
+      end
+
+      def ignore(module_id : String) : Array(DebugCallback)
+        return [] of DebugCallback if (manager = protocol_manager_by_module?(module_id)).nil?
+        manager.ignore_all(module_id)
       end
 
       # Metadata

--- a/src/placeos-core/process_manager/local.cr
+++ b/src/placeos-core/process_manager/local.cr
@@ -189,7 +189,7 @@ module PlaceOS::Core
         set_driver_protocol_manager(key, nil)
       end
 
-      private getter protocol_manager_lock = Mutex.new
+      private getter protocol_manager_lock = Mutex.new(protection: :reentrant)
 
       # Mapping from module_id to protocol manager
       @module_protocol_managers : Hash(String, Driver::Protocol::Management) = {} of String => Driver::Protocol::Management

--- a/src/placeos-edge/client.cr
+++ b/src/placeos-edge/client.cr
@@ -270,19 +270,19 @@ module PlaceOS::Edge
       !binary.nil?
     end
 
-    def fetch_binary(key : String) : Bytes?
+    def fetch_binary(key : String) : IO?
       response = Protocol.request(Protocol::Message::FetchBinary.new(key), expect: Protocol::Message::BinaryBody)
-      response.try &.binary
+      response.try &.io
     end
 
-    def add_binary(key : String, binary : Bytes)
+    def add_binary(key : String, binary : IO)
       path = path(key)
       Log.debug { {path: path, message: "writing binary"} }
       return true if File.exists?(path(key))
 
       # Default permissions + execute for owner
       File.open(path, mode: "w+", perm: File::Permissions.new(0o744)) do |file|
-        file.write(binary)
+        IO.copy(binary, file)
       end
     end
 


### PR DESCRIPTION
Resolves an issue where modules that were reloaded onto a new driver binary would not propagate any existing debug listeners to the module on the new driver.

Closes PlaceOS/rest-api/issues/94