### PR TITLE
improvement: reduce allocation when sending/receiving driver binaries

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -123,7 +123,7 @@ shards:
 
   placeos-models:
     git: https://github.com/placeos/models.git
-    version: 4.11.0
+    version: 4.12.1
 
   placeos-resource:
     git: https://github.com/place-labs/resource.git

--- a/src/placeos-core/client.cr
+++ b/src/placeos-core/client.cr
@@ -60,11 +60,7 @@ module PlaceOS::Core
       @connection = HTTP::Client.new(host: @host, port: @port)
     end
 
-    @connection : HTTP::Client?
-
-    protected def connection
-      @connection.as(HTTP::Client)
-    end
+    protected getter! connection : HTTP::Client
 
     protected getter connection_lock : Mutex = Mutex.new
 

--- a/src/placeos-core/process_manager/edge.cr
+++ b/src/placeos-core/process_manager/edge.cr
@@ -221,10 +221,7 @@ module PlaceOS::Core
 
     def fetch_binary(driver_key : String) : Protocol::Message::BinaryBody
       path = File.join(PlaceOS::Compiler.bin_dir, driver_key)
-
-      binary = Edge.read_file?(path)
-
-      Protocol::Message::BinaryBody.new(success: !binary.nil?, key: driver_key, binary: binary)
+      Protocol::Message::BinaryBody.new(success: File.exists?(path), key: driver_key, path: path)
     end
 
     # Metadata
@@ -308,17 +305,6 @@ module PlaceOS::Core
 
     def self.path_to_key(driver_path : String)
       driver_path.lchop(PlaceOS::Compiler.bin_dir).lstrip('/')
-    end
-
-    def self.read_file?(path : String) : Bytes?
-      File.open(path) do |file|
-        memory = IO::Memory.new
-        IO.copy file, memory
-        memory.to_slice
-      end
-    rescue e
-      Log.error(exception: e) { "failed to read #{path} into slice" }
-      nil
     end
   end
 end

--- a/src/placeos-edge/client.cr
+++ b/src/placeos-edge/client.cr
@@ -270,19 +270,19 @@ module PlaceOS::Edge
       !binary.nil?
     end
 
-    def fetch_binary(key : String) : Bytes?
+    def fetch_binary(key : String) : IO?
       response = Protocol.request(Protocol::Message::FetchBinary.new(key), expect: Protocol::Message::BinaryBody)
-      response.try &.binary
+      response.try &.io
     end
 
-    def add_binary(key : String, binary : Bytes)
+    def add_binary(key : String, binary : IO)
       path = path(key)
       Log.debug { {path: path, message: "writing binary"} }
       return true if File.exists?(path(key))
 
       # Default permissions + execute for owner
       File.open(path, mode: "w+", perm: File::Permissions.new(0o744)) do |file|
-        file.write(binary)
+        IO.copy(binary, file)
       end
     end
 


### PR DESCRIPTION
Skips an allocation into an intermediate `IO::Memory` when passing a driver binary to an edge node