### PR TITLE
refactor: use driver key internally, lock stabilisation

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -27,7 +27,7 @@ shards:
 
   clustering:
     git: https://github.com/place-labs/clustering.git
-    version: 2.0.4
+    version: 3.0.0
 
   connect-proxy:
     git: https://github.com/spider-gazelle/connect-proxy.git
@@ -51,7 +51,7 @@ shards:
 
   etcd:
     git: https://github.com/place-labs/crystal-etcd.git
-    version: 1.0.7
+    version: 1.1.1
 
   exec_from:
     git: https://github.com/place-labs/exec_from.git
@@ -75,7 +75,7 @@ shards:
 
   hound-dog:
     git: https://github.com/place-labs/hound-dog.git
-    version: 2.6.0
+    version: 2.6.1
 
   http-params-serializable:
     git: https://github.com/caspiano/http-params-serializable.git

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-core
-version: 3.3.0
+version: 3.4.0
 crystal: ~> 0.36
 
 targets:

--- a/shard.yml
+++ b/shard.yml
@@ -15,7 +15,7 @@ dependencies:
 
   clustering:
     github: place-labs/clustering
-    version: ~> 2.0
+    version: ~> 3.0
 
   habitat:
     github: luckyframework/habitat

--- a/spec/processes/edge_spec.cr
+++ b/spec/processes/edge_spec.cr
@@ -40,7 +40,7 @@ module PlaceOS::Core::ProcessManager
         module: mod,
         edge: edge,
         driver_path: driver_path,
-        driver_key: Edge.path_to_key(driver_path),
+        driver_key: ProcessManager.path_to_key(driver_path),
       )
 
       client, process_manager = client_server(edge.id.as(String))
@@ -53,7 +53,7 @@ module PlaceOS::Core::ProcessManager
     it "debug" do
       with_edge do |ctx, _client, pm|
         module_id = ctx.module.id.as(String)
-        pm.load(module_id: module_id, driver_path: ctx.driver_path)
+        pm.load(module_id: module_id, driver_key: ctx.driver_path)
         pm.start(module_id: module_id, payload: ModuleManager.start_payload(ctx.module))
 
         message_channel = Channel(String).new
@@ -77,7 +77,7 @@ module PlaceOS::Core::ProcessManager
     describe "driver_loaded?" do
       it "confirms a driver is loaded" do
         with_edge do |ctx, client, pm|
-          pm.load(module_id: "mod", driver_path: ctx.driver_key)
+          pm.load(module_id: "mod", driver_key: ctx.driver_key)
           client.driver_loaded?(ctx.driver_key).should be_true
           pm.driver_loaded?(ctx.driver_key).should be_true
         end
@@ -95,7 +95,7 @@ module PlaceOS::Core::ProcessManager
       it "returns driver status if present" do
         # TODO: Could do with a double check of values
         with_edge do |ctx, client, pm|
-          pm.load(module_id: "mod", driver_path: ctx.driver_path)
+          pm.load(module_id: "mod", driver_key: ctx.driver_path)
 
           pm.driver_status(ctx.driver_path).should_not be_nil
           client.driver_status(ctx.driver_key).should_not be_nil
@@ -113,7 +113,7 @@ module PlaceOS::Core::ProcessManager
     it "execute" do
       with_edge do |ctx, _client, pm|
         module_id = ctx.module.id.as(String)
-        pm.load(module_id: module_id, driver_path: ctx.driver_path)
+        pm.load(module_id: module_id, driver_key: ctx.driver_path)
         pm.start(module_id: module_id, payload: ModuleManager.start_payload(ctx.module))
         result = pm.execute(module_id: module_id, payload: ModuleManager.execute_payload(:used_for_place_testing))
         result.should eq %("you can delete this file")
@@ -123,7 +123,7 @@ module PlaceOS::Core::ProcessManager
     it "ignore" do
       with_edge do |ctx, _client, pm|
         module_id = ctx.module.id.as(String)
-        pm.load(module_id: module_id, driver_path: ctx.driver_path)
+        pm.load(module_id: module_id, driver_key: ctx.driver_path)
         pm.start(module_id: module_id, payload: ModuleManager.start_payload(ctx.module))
         message_channel = Channel(String).new
 
@@ -188,7 +188,7 @@ module PlaceOS::Core::ProcessManager
         pm.module_loaded?("mod").should be_false
         client.module_loaded?("mod").should be_false
 
-        pm.load(module_id: "mod", driver_path: ctx.driver_path)
+        pm.load(module_id: "mod", driver_key: ctx.driver_path)
 
         pm.driver_loaded?(ctx.driver_path).should be_true
         client.driver_loaded?(ctx.driver_key).should be_true
@@ -207,7 +207,7 @@ module PlaceOS::Core::ProcessManager
     describe "module_loaded?" do
       it "confirms a module is loaded" do
         with_edge do |ctx, _client, pm|
-          pm.load(module_id: "mod", driver_path: ctx.driver_path)
+          pm.load(module_id: "mod", driver_key: ctx.driver_path)
           pm.module_loaded?("mod").should be_true
         end
       end
@@ -221,7 +221,7 @@ module PlaceOS::Core::ProcessManager
 
     it "run_count" do
       with_edge do |ctx, _client, pm|
-        pm.load(module_id: "mod", driver_path: ctx.driver_path)
+        pm.load(module_id: "mod", driver_key: ctx.driver_path)
         pm.run_count.should eq({drivers: 1, modules: 1})
       end
     end
@@ -235,7 +235,7 @@ module PlaceOS::Core::ProcessManager
     it "start" do
       with_edge do |ctx, client, pm|
         module_id = ctx.module.id.as(String)
-        pm.load(module_id: module_id, driver_path: ctx.driver_path)
+        pm.load(module_id: module_id, driver_key: ctx.driver_path)
         pm.start(module_id: module_id, payload: ModuleManager.start_payload(ctx.module))
         pm.loaded_modules.should eq({ctx.driver_key => [module_id]})
         client.loaded_modules.should eq({ctx.driver_key => [module_id]})
@@ -268,7 +268,7 @@ module PlaceOS::Core::ProcessManager
           module_id = "mod"
           File.copy(ctx.driver_path, path)
 
-          pm.load(module_id: module_id, driver_path: path)
+          pm.load(module_id: module_id, driver_key: path)
           pm.driver_loaded?(path).should be_true
           pm.module_loaded?(module_id).should be_true
           pm.unload(module_id)
@@ -284,8 +284,8 @@ module PlaceOS::Core::ProcessManager
           module1 = "mod1"
           File.copy(ctx.driver_path, path)
 
-          pm.load(module_id: module0, driver_path: path)
-          pm.load(module_id: module1, driver_path: path)
+          pm.load(module_id: module0, driver_key: path)
+          pm.load(module_id: module1, driver_key: path)
           pm.driver_loaded?(path).should be_true
           pm.module_loaded?(module0).should be_true
           pm.module_loaded?(module1).should be_true

--- a/src/constants.cr
+++ b/src/constants.cr
@@ -21,9 +21,7 @@ module PlaceOS::Core
   CORE_HOST = ENV["CORE_HOST"]? || System.hostname
   CORE_PORT = (ENV["CORE_PORT"]? || "3000").to_i
 
-  PROD = ENV["SG_ENV"]? == "production"
+  PROD = ENV["SG_ENV"]?.try(&.downcase) == "production"
 
-  def self.production?
-    PROD
-  end
+  class_getter? production : Bool = PROD
 end

--- a/src/controllers/chaos.cr
+++ b/src/controllers/chaos.cr
@@ -10,7 +10,7 @@ module PlaceOS::Core::Api
 
     # terminate a process
     post "/terminate", :terminate do
-      driver_path = params["path"]
+      driver_key = params["path"]
       edge_id = params["edge_id"]?.presence
 
       # TODO: move this to ModuleManager
@@ -20,9 +20,9 @@ module PlaceOS::Core::Api
                   module_manager.edge_processes.for?(edge_id)
                 end
 
-      head :not_found unless manager && manager.driver_loaded?(driver_path)
+      head :not_found unless manager && manager.driver_loaded?(driver_key)
 
-      manager.kill(driver_path)
+      manager.kill(driver_key)
 
       head :ok
     end

--- a/src/core-app.cr
+++ b/src/core-app.cr
@@ -61,7 +61,7 @@ Signal::TERM.trap &terminate
 
 # Allow signals to change the log level at run-time
 logging = Proc(Signal, Nil).new do |signal|
-  log_level = signal.usr1? ? Log::Severity::Debug : Log::Severity::Info
+  log_level = signal.usr1? ? Log::Severity::Trace : Log::Severity::Info
   log_backend = PlaceOS::LogBackend.log_backend
   puts " > Log level changed to #{log_level}"
   Log.builder.bind "action-controller.*", log_level, log_backend

--- a/src/core-app.cr
+++ b/src/core-app.cr
@@ -1,5 +1,6 @@
 require "option_parser"
 
+require "./ext"
 require "./config"
 
 # Server defaults

--- a/src/core-app.cr
+++ b/src/core-app.cr
@@ -1,6 +1,5 @@
 require "option_parser"
 
-require "./ext"
 require "./config"
 
 # Server defaults

--- a/src/ext.cr
+++ b/src/ext.cr
@@ -1,0 +1,6 @@
+# TODO: remove when URI serialises to json
+class URI
+  def to_json(json)
+    json.string(to_s)
+  end
+end

--- a/src/placeos-core.cr
+++ b/src/placeos-core.cr
@@ -1,5 +1,7 @@
 require "action-controller/logger"
 require "log_helper"
+
+require "./ext"
 require "./placeos-core/*"
 require "./constants"
 

--- a/src/placeos-core/compilation.cr
+++ b/src/placeos-core/compilation.cr
@@ -104,8 +104,7 @@ module PlaceOS
       stale_path = module_manager.reload_modules(driver)
 
       # Remove the stale driver if there was one
-      remove_stale_driver(
-        driver_id: driver_id,
+      remove_stale_driver(driver_id: driver_id,
         path: stale_path,
       )
 
@@ -119,12 +118,12 @@ module PlaceOS
 
     # Remove the stale driver binary if there was one
     #
-    def self.remove_stale_driver(path : String?, driver_id : String)
+    def self.remove_stale_driver(path : Path?, driver_id : String)
       return unless path
-      Log.info { {message: "removing stale driver binary", driver_id: driver_id, path: path} }
+      Log.info { {message: "removing stale driver binary", driver_id: driver_id, path: path.to_s} }
       File.delete(path) if File.exists?(path)
     rescue
-      Log.error { {message: "failed to remove stale binary", driver_id: driver_id, path: path} }
+      Log.error { {message: "failed to remove stale binary", driver_id: driver_id, path: path.to_s} }
     end
 
     def self.update_driver_commit(driver : Model::Driver, commit : String, startup : Bool)

--- a/src/placeos-core/module_manager.cr
+++ b/src/placeos-core/module_manager.cr
@@ -74,10 +74,12 @@ module PlaceOS::Core
       super()
     end
 
+    private getter stabilize_lock = Mutex.new
+
     def start
       # Start clustering process
       clustering.start(on_stable: ->publish_version(String)) do |nodes|
-        stabilize(nodes)
+        stabilize_lock.synchronize { stabilize(nodes) }
       end
 
       super

--- a/src/placeos-core/module_manager.cr
+++ b/src/placeos-core/module_manager.cr
@@ -285,11 +285,11 @@ module PlaceOS::Core
     # Run through modules and load to a stable state.
     #
     # Uses a semaphore to ensure intermediary cluster events don't trigger stabilization.
-    def stabilize(nodes : Array(HoundDog::Service::Node))
+    def stabilize(nodes : Array(HoundDog::Service::Node)) : Bool
       semaphore.add(1)
       stabilize_lock.synchronize do
         semaphore.add(-1)
-        return unless semaphore.get.zero?
+        return false unless semaphore.get.zero?
 
         Log.debug { {message: "stabilizing", nodes: nodes.to_json} }
 
@@ -302,6 +302,7 @@ module PlaceOS::Core
             Log.error(exception: e) { {message: "failed to load module during stabilization", module_id: m.id, name: m.name, custom_name: m.custom_name} }
           end
         end
+        true
       end
     end
 

--- a/src/placeos-core/process_manager.cr
+++ b/src/placeos-core/process_manager.cr
@@ -11,7 +11,7 @@ module PlaceOS::Core
       Log = ::Log.for(self)
     end
 
-    abstract def load(module_id : String, driver_path : String)
+    abstract def load(module_id : String, driver_key : String)
 
     abstract def unload(module_id : String)
 
@@ -25,7 +25,7 @@ module PlaceOS::Core
 
     abstract def ignore(module_id : String) : Array(DebugCallback)
 
-    abstract def kill(driver_path : String)
+    abstract def kill(driver_key : String)
 
     # Execute a driver method on a module
     #
@@ -73,7 +73,7 @@ module PlaceOS::Core
 
     # Generate a system status report
     #
-    abstract def driver_status(driver_path : String) : DriverStatus?
+    abstract def driver_status(driver_key : String) : DriverStatus?
 
     record(
       SystemStatus,
@@ -98,7 +98,7 @@ module PlaceOS::Core
 
     # Check for the presence of a running driver on a ProcessManager
     #
-    abstract def driver_loaded?(driver_path : String) : Bool
+    abstract def driver_loaded?(driver_key : String) : Bool
 
     # Returns the count of ...
     # - unique drivers running
@@ -109,5 +109,11 @@ module PlaceOS::Core
     # Count of distinct modules loaded on a ProcessManager
     #
     abstract def loaded_modules
+
+    # Helper for extracting the driver key
+    #
+    def self.path_to_key(path : String) : String
+      Path[path].basename
+    end
   end
 end

--- a/src/placeos-core/process_manager/edge.cr
+++ b/src/placeos-core/process_manager/edge.cr
@@ -86,8 +86,8 @@ module PlaceOS::Core
       end
     end
 
-    def load(module_id : String, driver_path : String)
-      !!Protocol.request(Protocol::Message::Load.new(module_id, Edge.path_to_key(driver_path)), expect: Protocol::Message::Success)
+    def load(module_id : String, driver_key : String)
+      !!Protocol.request(Protocol::Message::Load.new(module_id, ProcessManager.path_to_key(driver_key)), expect: Protocol::Message::Success)
     end
 
     def unload(module_id : String)
@@ -102,8 +102,8 @@ module PlaceOS::Core
       !!Protocol.request(Protocol::Message::Stop.new(module_id), expect: Protocol::Message::Success)
     end
 
-    def kill(driver_path : String)
-      !!Protocol.request(Protocol::Message::Kill.new(Edge.path_to_key(driver_path)), expect: Protocol::Message::Success)
+    def kill(driver_key : String)
+      !!Protocol.request(Protocol::Message::Kill.new(ProcessManager.path_to_key(driver_key)), expect: Protocol::Message::Success)
     end
 
     alias Module = Protocol::Message::RegisterResponse::Module
@@ -231,8 +231,8 @@ module PlaceOS::Core
     # Metadata
     ###############################################################################################
 
-    def driver_loaded?(driver_path : String) : Bool
-      !!Protocol.request(Protocol::Message::DriverLoaded.new(Edge.path_to_key(driver_path)), expect: Protocol::Message::Success)
+    def driver_loaded?(driver_key : String) : Bool
+      !!Protocol.request(Protocol::Message::DriverLoaded.new(ProcessManager.path_to_key(driver_key)), expect: Protocol::Message::Success)
     end
 
     def module_loaded?(module_id : String) : Bool
@@ -262,10 +262,10 @@ module PlaceOS::Core
       response.status
     end
 
-    def driver_status(driver_path : String) : DriverStatus?
-      response = Protocol.request(Protocol::Message::DriverStatus.new(Edge.path_to_key(driver_path)), expect: Protocol::Message::DriverStatusResponse)
+    def driver_status(driver_key : String) : DriverStatus?
+      response = Protocol.request(Protocol::Message::DriverStatus.new(ProcessManager.path_to_key(driver_key)), expect: Protocol::Message::DriverStatusResponse)
 
-      Log.warn { {message: "failed to request driver status", driver_path: driver_path} } if response.nil?
+      Log.warn { {message: "failed to request driver status", driver_key: driver_key} } if response.nil?
 
       response.try &.status
     end
@@ -305,10 +305,6 @@ module PlaceOS::Core
       exception = match.try &.captures.first || "Exception"
       message = match.pre_match unless match.nil?
       {message, exception}
-    end
-
-    def self.path_to_key(driver_path : String)
-      driver_path.lchop(PlaceOS::Compiler.bin_dir).lstrip('/')
     end
   end
 end

--- a/src/placeos-core/process_manager/local.cr
+++ b/src/placeos-core/process_manager/local.cr
@@ -164,7 +164,11 @@ module PlaceOS::Core
       def loaded_modules : Hash(String, Array(String))
         protocol_manager_lock.synchronize do
           Promise.all(@driver_protocol_managers.map { |driver, manager|
-            Promise.defer { {driver, manager.info} }
+            Promise.defer do
+              info = manager.info
+              Log.trace { {info: manager.info.to_json, driver: driver} }
+              {driver, info}
+            end
           }).then(&.to_h).get
         end
       end

--- a/src/placeos-edge.cr
+++ b/src/placeos-edge.cr
@@ -1,6 +1,8 @@
 require "action-controller/logger"
 require "log_helper"
 
+require "./ext"
+
 # :nodoc:
 abstract class PlaceOS::Driver; end
 


### PR DESCRIPTION
- Added a lock around the stabilizing method in `module_manager.cr` to ensure that only a single module load occurs
- Refactored all internal references to use the driver binary name, and only use the path when starting the driver protocol manager