### PR TITLE
feat(logging): signal to trace logging and back

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-core
-version: 3.7.1
+version: 3.7.2
 crystal: ~> 1.0
 
 targets:


### PR DESCRIPTION
Sets all log backends to trace if signalled `USR1` and back to the standard configuration (respecting production logging) via `USR2`

```
# To enable trace
$ docker exec core kill -USR1 1
# To return to the default logging
$ docker exec core kill -USR2 1
```