### PR TITLE
test: robust module mapping updates

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -127,7 +127,7 @@ shards:
 
   placeos-models:
     git: https://github.com/placeos/models.git
-    version: 4.15.5
+    version: 4.16.0
 
   placeos-resource:
     git: https://github.com/place-labs/resource.git

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-core
-version: 3.8.0
+version: 3.8.1
 crystal: ~> 1.0
 
 targets:

--- a/spec/cloning_spec.cr
+++ b/spec/cloning_spec.cr
@@ -78,8 +78,8 @@ module PlaceOS::Core
 
       # Check the repository has been deleted
       Dir.exists?(full_repository_path).should be_false
-
-      cloner.stop
+    ensure
+      cloner.try &.stop
     end
   end
 end

--- a/spec/cloning_spec.cr
+++ b/spec/cloning_spec.cr
@@ -44,6 +44,8 @@ module PlaceOS::Core
       Model::Repository.find!(repo.id.as(String)).commit_hash.should eq commit_hash
 
       Compiler::GitCommands.current_branch(full_repository_path).should eq secondary_branch
+    ensure
+      repo.try &.destroy
     end
 
     it "clones/deletes repositories" do
@@ -80,6 +82,7 @@ module PlaceOS::Core
       Dir.exists?(full_repository_path).should be_false
     ensure
       cloner.try &.stop
+      repo.try &.destroy
     end
   end
 end

--- a/spec/controllers/command_spec.cr
+++ b/spec/controllers/command_spec.cr
@@ -52,16 +52,7 @@ module PlaceOS::Core
         mod_id = mod.id.as(String)
 
         # Mock resources
-        clustering_mock = MockClustering.new(
-          uri: CORE_URL,
-          discovery: discovery_mock,
-        )
-
-        module_manager = ModuleManager.new(
-          uri: CORE_URL,
-          clustering: clustering_mock,
-          discovery: clustering_mock.discovery,
-        )
+        module_manager = module_manager_mock
 
         # Load module
         module_manager.load_module(mod)

--- a/spec/controllers/drivers_spec.cr
+++ b/spec/controllers/drivers_spec.cr
@@ -9,7 +9,7 @@ module PlaceOS::Core
 
     describe "drivers/" do
       it "lists drivers" do
-        repo, _, _ = create_resources
+        repo, _, _, resource_manager = create_resources
 
         path = "#{namespace}?repository=#{repo.folder_name}"
         ctx = context("GET", path, json_headers)
@@ -25,12 +25,14 @@ module PlaceOS::Core
         ctx.response.status_code.should eq 200
         result.should_not be_nil
         result.not_nil!.sort.should eq ["drivers/place/edge_demo.cr", "drivers/place/feature_test.cr", "drivers/place/private_helper.cr"]
+      ensure
+        resource_manager.try &.stop
       end
     end
 
     describe "drivers/:id/compiled" do
       it "checks if a driver has been compiled" do
-        repo, driver, _ = create_resources
+        repo, driver, _, resource_manager = create_resources
         uri = URI.encode_www_form(SPEC_DRIVER)
 
         params = HTTP::Params{
@@ -47,12 +49,14 @@ module PlaceOS::Core
 
         ctx.response.status_code.should eq 200
         Bool.from_json(ctx.response.output.to_s).should be_true
+      ensure
+        resource_manager.try &.stop
       end
     end
 
     describe "drivers/:id" do
       it "lists commits for a particular driver" do
-        repo, _, _ = create_resources
+        repo, _, _, resource_manager = create_resources
         uri = URI.encode_www_form(SPEC_DRIVER)
 
         path = File.join(namespace, uri, "?repository=#{repo.folder_name}")
@@ -66,6 +70,8 @@ module PlaceOS::Core
         expected = PlaceOS::Compiler::Helper.commits(URI.decode(uri), repo.folder_name, 50)
         result = Array(PlaceOS::Compiler::GitCommands::Commit).from_json(ctx.response.output.to_s)
         result.should eq expected
+      ensure
+        resource_manager.try &.stop
       end
     end
   end

--- a/spec/controllers/status_spec.cr
+++ b/spec/controllers/status_spec.cr
@@ -9,7 +9,7 @@ module PlaceOS::Core
 
     describe "status/" do
       it "renders data about node" do
-        repo, driver, _ = create_resources
+        repo, driver, _, resource_manager = create_resources
 
         driver.reload!
 
@@ -26,6 +26,8 @@ module PlaceOS::Core
         status.compiled_drivers.should contain binary
         status.available_repositories.should contain repo.folder_name
         status.run_count.should eq ({local: {modules: 0, drivers: 0}, edge: {} of String => NamedTuple(modules: Int32, drivers: Int32)})
+      ensure
+        resource_manager.try &.stop
       end
 
       pending "deletes standalone driver binary used for metadata"

--- a/spec/helper.cr
+++ b/spec/helper.cr
@@ -163,8 +163,10 @@ def create_resources(fresh : Bool = false, process : Bool = true)
 end
 
 class DiscoveryMock < HoundDog::Discovery
+  DOES_NOT_MAP = "<does-not-map>"
+
   def own_node?(key : String) : Bool
-    true
+    key != DOES_NOT_MAP
   end
 
   def etcd_nodes

--- a/spec/helper.cr
+++ b/spec/helper.cr
@@ -62,6 +62,9 @@ Spec.before_suite do
   # Set the working directory before specs
   set_temporary_working_directory
   Log.builder.bind("*", backend: PlaceOS::Core::LOG_STDOUT, level: Log::Severity::Trace)
+  Log.builder.bind("http.client", backend: PlaceOS::Core::LOG_STDOUT, level: Log::Severity::Warn)
+  Log.builder.bind("clustering", backend: PlaceOS::Core::LOG_STDOUT, level: Log::Severity::Error)
+  Log.builder.bind("hound_dog.*", backend: PlaceOS::Core::LOG_STDOUT, level: Log::Severity::Error)
 end
 
 Spec.after_suite do

--- a/spec/helper.cr
+++ b/spec/helper.cr
@@ -38,6 +38,12 @@ def discovery_mock
   DiscoveryMock.new("core", uri: CORE_URL)
 end
 
+def module_manager_mock
+  discovery = discovery_mock
+  clustering = MockClustering.new(uri: CORE_URL, discovery: discovery)
+  PlaceOS::Core::ModuleManager.new(CORE_URL, discovery: discovery, clustering: clustering)
+end
+
 macro around_suite(block)
   Spec.before_suite do
     {{ block }}.call

--- a/spec/helper.cr
+++ b/spec/helper.cr
@@ -155,11 +155,10 @@ def create_resources(fresh : Bool = false, process : Bool = true)
   _, repository, driver, mod = setup(fresh)
 
   # Clone, compile
-  if process
-    PlaceOS::Core::ResourceManager.instance(testing: true).start { }
-  end
+  resource_manager = PlaceOS::Core::ResourceManager.new(testing: true)
+  resource_manager.start { } if process
 
-  {repository, driver, mod}
+  {repository, driver, mod, resource_manager}
 end
 
 class DiscoveryMock < HoundDog::Discovery

--- a/spec/mappings/control_system_modules_spec.cr
+++ b/spec/mappings/control_system_modules_spec.cr
@@ -1,5 +1,131 @@
 require "../helper"
 
-module PlaceOS::Core::Mappings
-  pending ControlSystemModules, tags: "resource"
+module PlaceOS::Core
+  class Mock < ModuleManager
+    FAILS_TO_REFRESH = "fails-to-refresh"
+
+    def self.failing_id
+      "mod-#{Random::DEFAULT.hex(6)}-#{FAILS_TO_REFRESH}"
+    end
+
+    def refresh_module(mod)
+      raise "failed to refresh!" if mod.id.as(String).ends_with? FAILS_TO_REFRESH
+      true
+    end
+  end
+
+  describe Mappings::ControlSystemModules, tags: "resource" do
+    describe ".update_mapping" do
+      it "ignores systems not mapped to node" do
+        control_system = Model::Generator.control_system
+        control_system.id = DiscoveryMock::DOES_NOT_MAP
+        control_system_modules = Mappings::ControlSystemModules.new(module_manager: module_manager_mock, startup: false)
+        control_system_modules.process_resource(:updated, control_system).skipped?.should be_true
+      end
+
+      it "updates mappings regardless of refresh failures" do
+        device_driver = Model::Generator.driver(:device).save!
+        logic_driver = Model::Generator.driver(:logic).save!
+
+        device_modules = (0...2).map do
+          m = Model::Generator.module(device_driver)
+          m.custom_name = "device"
+          m.save!
+        end
+
+        cs = Model::Generator.control_system
+        cs.modules = device_modules.compact_map &.id
+        cs.save!
+
+        borked = Model::Generator.module(logic_driver, cs)
+        borked._new_flag = true
+        borked.id = Mock.failing_id
+        borked.custom_name = "logic"
+        borked.save!
+
+        storage = Driver::RedisStorage.new(cs.id.as(String), "system")
+        storage["logic/1"] = borked.id
+        # Place "device" modules in opposite order
+        storage["device/1"] = device_modules[1].id
+        storage["device/2"] = device_modules[0].id
+        storage["device/3"] = "doesn't exist"
+
+        Mappings::ControlSystemModules.update_mapping(
+          cs,
+          startup: true,
+          module_manager: Mock.new(CORE_URL),
+        ).success?.should be_true
+
+        storage["logic/1"]?.should eq borked.id
+        storage["device/1"]?.should eq device_modules[0].id
+        storage["device/2"]?.should eq device_modules[1].id
+        storage["device/3"]?.should be_nil
+      end
+    end
+
+    describe ".set_mappings" do
+      it "clears mappings before setting them" do
+        cs = Model::Generator.control_system
+        cs.id = UUID.random.to_s
+
+        storage = Driver::RedisStorage.new(cs.id.as(String), "system")
+        mock_key = "bar/1"
+        storage[mock_key] = "foo"
+        storage[mock_key].should eq "foo"
+
+        Mappings::ControlSystemModules.set_mappings(cs, nil).should eq({} of String => String)
+        storage[mock_key]?.should be_nil
+      end
+    end
+
+    describe ".update_logic_modules" do
+      it "does not update if system is destroyed" do
+        cs = Model::ControlSystem.new
+        cs.destroyed = true
+        Mappings::ControlSystemModules.update_logic_modules(cs, module_manager_mock).should eq 0
+      end
+
+      it "returns the number of refreshed modules" do
+        driver = Model::Generator.driver(:logic).save!
+        cs = Model::Generator.control_system.save!
+
+        mock_manager = Mock.new(CORE_URL)
+
+        mods = (0...2).map do
+          Model::Generator.module(driver, cs)
+        end
+
+        Mappings::ControlSystemModules.update_logic_modules(cs, mock_manager).should eq 0
+
+        mods[0].save!
+        Mappings::ControlSystemModules.update_logic_modules(cs, mock_manager).should eq 1
+
+        mods[1].save!
+        Mappings::ControlSystemModules.update_logic_modules(cs, mock_manager).should eq 2
+      end
+
+      it "gracefully handles refresh failures" do
+        driver = Model::Generator.driver(:logic).save!
+        cs = Model::Generator.control_system.save!
+
+        mock_manager = Mock.new(CORE_URL)
+        okay = Model::Generator.module(driver, cs)
+        okay.save!
+        Mappings::ControlSystemModules.update_logic_modules(cs, mock_manager).should eq 1
+
+        fails = Model::Generator.module(driver, cs)
+        fails._new_flag = true
+        fails.id = Mock.failing_id
+        fails.save!
+
+        # Updated the sole good module
+        Mappings::ControlSystemModules.update_logic_modules(cs, mock_manager).should eq 1
+
+        okay.destroy
+
+        # No modules to update
+        Mappings::ControlSystemModules.update_logic_modules(cs, mock_manager).should eq 0
+      end
+    end
+  end
 end

--- a/spec/mappings/control_system_modules_spec.cr
+++ b/spec/mappings/control_system_modules_spec.cr
@@ -104,7 +104,7 @@ module PlaceOS::Core
         Mappings::ControlSystemModules.update_logic_modules(cs, mock_manager).should eq 2
       end
 
-      it "gracefully handles refresh failures" do
+      it "handles refresh failures" do
         driver = Model::Generator.driver(:logic).save!
         cs = Model::Generator.control_system.save!
 

--- a/spec/module_manager_spec.cr
+++ b/spec/module_manager_spec.cr
@@ -7,7 +7,7 @@ module PlaceOS::Core
 
     describe "local" do
       it "loads modules that hash to the node" do
-        create_resources
+        _, _, _, resource_manager = create_resources
 
         # Start module manager
         module_manager = module_manager_mock
@@ -16,6 +16,9 @@ module PlaceOS::Core
         # Check that the module is loaded, and the module manager can be received
         module_manager.local_processes.run_count[:modules].should eq 1
         module_manager.stop
+      ensure
+        module_manager.try &.stop
+        resource_manager.try &.stop
       end
 
       it "load_module" do
@@ -55,9 +58,9 @@ module PlaceOS::Core
         module_manager.local_processes.protocol_manager_by_driver?(driver_path).should_not be_nil
 
         module_manager.local_processes.protocol_manager_by_module?(mod_id).should eq(module_manager.local_processes.protocol_manager_by_driver?(driver_path))
-
-        module_manager.stop
-        resource_manager.stop
+      ensure
+        module_manager.try &.stop
+        resource_manager.try &.stop
       end
     end
 
@@ -84,7 +87,8 @@ module PlaceOS::Core
 
         # Check that the node is no longer registered in etcd
         module_manager.discovery.nodes.map(&.[:name]).should_not contain(module_manager.discovery.name)
-        module_manager.stop
+      ensure
+        module_manager.try &.stop
       end
     end
   end

--- a/spec/module_manager_spec.cr
+++ b/spec/module_manager_spec.cr
@@ -9,19 +9,8 @@ module PlaceOS::Core
       it "loads modules that hash to the node" do
         create_resources
 
-        discovery_mock = DiscoveryMock.new("core", uri: CORE_URL)
-        clustering_mock = MockClustering.new(
-          uri: CORE_URL,
-          discovery: discovery_mock,
-        )
-
-        module_manager = ModuleManager.new(
-          uri: CORE_URL,
-          clustering: clustering_mock,
-          discovery: discovery_mock,
-        )
-
         # Start module manager
+        module_manager = module_manager_mock
         module_manager.start
 
         # Check that the module is loaded, and the module manager can be received
@@ -32,7 +21,7 @@ module PlaceOS::Core
       it "load_module" do
         _, repo, driver, mod = setup
 
-        module_manager = ModuleManager.new(CORE_URL, discovery: DiscoveryMock.new("core", uri: CORE_URL))
+        module_manager = module_manager_mock
 
         cloning = Cloning.new(testing: true)
         compilation = Compilation.new(startup: true, module_manager: module_manager)

--- a/spec/resource_manager_spec.cr
+++ b/spec/resource_manager_spec.cr
@@ -25,7 +25,8 @@ module PlaceOS::Core
       {1, 2}.any?(resource_manager.compilation.processed.size).should be_true
 
       resource_manager.control_system_modules.processed.size.should eq 0
-      resource_manager.stop
+    ensure
+      resource_manager.try &.stop
     end
   end
 end


### PR DESCRIPTION
- `ControlSystemModules`: if errors raised when updating modules, the mappings process is unaffected.
- `SettingsUpdates`: if errors raised when updating a module onto new settings, the rest of the module reloads are unaffected
- DRY out a few mocks used across the test suite 
- Stop using a shared global `ResourceManager` instance in specs

Fixes #92