### PR TITLE
build: bump to crystal 1.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 # One of `core` | `edge`
 ARG TARGET=core
+ARG CRYSTAL_VERSION=1.1.1
 
-FROM crystallang/crystal:1.0.0-alpine as build
+FROM crystallang/crystal:${CRYSTAL_VERSION}-alpine as build
 
+ARG TARGET
 ARG PLACE_COMMIT="DEV"
 ARG PLACE_VERSION="DEV"
-ARG TARGET
 
 WORKDIR /app
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-ARG crystal_version=1.0.0
+ARG crystal_version=1.1.1
 FROM crystallang/crystal:${crystal_version}-alpine
 
 WORKDIR /app


### PR DESCRIPTION
Bumps crystal to v1.1.1

This enables use of the [crunits library](https://github.com/spider-gazelle/crunits) in drivers