### PR TITLE
Cleaner CI status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
           - 1.1.1
         experimental: [false]
         include:
-          crystal: nightly
-          experimental: true
+          - crystal: nightly
+            experimental: true
     steps:
       - uses: actions/checkout@v2
       - name: Run docker-compose test environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   test:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
         crystal:
           - 1.0.0
           - 1.1.1
-          - nightly
+        experimental: [false]
+        include:
+          crystal: nightly
+          experimental: true
     steps:
       - uses: actions/checkout@v2
       - name: Run docker-compose test environment


### PR DESCRIPTION
Prevents failures when running against `crystal:nightly` from flagging a commit as not passing CI.