### PR TITLE
chore: placeos-models ~>5.9

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -51,7 +51,7 @@ dependencies:
 
   placeos-models:
     github: placeos/models
-    version: ~> 5.3
+    version: ~> 5.9
 
   placeos-resource:
     github: place-labs/resource


### PR DESCRIPTION
Updates minimum supported placeos-models version.

v5.10.0 was already locked, but bumping min spec for safety.