### PR TITLE
ci: use standard CRYSTAL_VERSION

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,5 +1,5 @@
-ARG crystal_version=1.1.1
-FROM crystallang/crystal:${crystal_version}-alpine
+ARG CRYSTAL_VERSION=1.1.1
+FROM crystallang/crystal:${CRYSTAL_VERSION}-alpine
 
 WORKDIR /app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       context: ./
       dockerfile: Dockerfile.test
       args:
-        crystal_version: ${CRYSTAL_VERSION:-1.0.0}
+        CRYSTAL_VERSION: ${CRYSTAL_VERSION:-1.1.1}
     volumes:
       - ./spec:/app/spec
       - ./src:/app/src


### PR DESCRIPTION
Support `CRYSTAL_VERSION` build argument when building the image