### PR TITLE
ci: split tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,41 @@ name: CI
 on: push
 jobs:
   test:
-    uses: PlaceOS/.github/.github/workflows/containerised-test.yml@main
+    name: "${{ !matrix.stable && '🚧 ' || ''}}crystal: ${{ matrix.crystal }}, MT: ${{ matrix.MT }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        subset:
+          - api
+          - mappings
+          - resource
+        crystal:
+          - 1.1.1
+          - 1.2.0
+        MT: [false]
+        stable: [true]
+        include:
+          - crystal: nightly
+            stable: false
+            MT: false
+            subset: api
+          - crystal: nightly
+            stable: false
+            MT: false
+            subset: mappings
+          - crystal: nightly
+            stable: false
+            MT: false
+            subset: resource
+    continue-on-error: ${{ !matrix.stable }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Test ${{ matrix.subset }}
+        timout-minutes: 25
+        run: ./test ${{ matrix.MT && '-Dpreview_mt' || '' }} --tags ${{ matrix.subset }}
+        env:
+          CRYSTAL_VERSION: ${{ matrix.crystal }}
 
   crystal-style:
     uses: PlaceOS/.github/.github/workflows/crystal-style.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
         subset:
           - api
           - mappings
+          - processes
           - resource
         crystal:
           - 1.1.1
@@ -28,12 +29,15 @@ jobs:
           - crystal: nightly
             stable: false
             MT: false
+            subset: processes
+          - crystal: nightly
+            stable: false
+            MT: false
             subset: resource
     continue-on-error: ${{ !matrix.stable }}
     steps:
       - uses: actions/checkout@v2
       - name: Test ${{ matrix.subset }}
-        timout-minutes: 25
         run: ./test ${{ matrix.MT && '-Dpreview_mt' || '' }} --tags ${{ matrix.subset }}
         env:
           CRYSTAL_VERSION: ${{ matrix.crystal }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on: push
 jobs:
   test:
-    name: "${{ !matrix.stable && '🚧 ' || ''}}crystal: ${{ matrix.crystal }}, MT: ${{ matrix.MT }}"
+    name: "${{ !matrix.stable && '🚧 ' || ''}}crystal: ${{ matrix.crystal }}, subset: ${{ matrix.subset }}, MT: ${{ matrix.MT }}"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Test ${{ matrix.subset }}
-        run: ./test ${{ matrix.MT && '-Dpreview_mt' || '' }} --tags ${{ matrix.subset }}
+        run: ./test ${{ matrix.MT && '-Dpreview_mt' || '' }} --tag ${{ matrix.subset }}
         env:
           CRYSTAL_VERSION: ${{ matrix.crystal }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Test ${{ matrix.subset }}
-        run: ./test ${{ matrix.MT && '-Dpreview_mt' || '' }} --tag ${{ matrix.subset }}
+        run: ./test ${{ matrix.MT && '-Dpreview_mt' || '' }} --tag ${{ matrix.subset }} --order random
         env:
           CRYSTAL_VERSION: ${{ matrix.crystal }}
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -28,4 +28,4 @@ RUN mkdir -p /app/bin/drivers
 # These provide certificate chain validation where communicating with external services over TLS
 ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 
-CMD ["/app/scripts/entrypoint.sh"]
+ENTRYPOINT ["/app/scripts/entrypoint.sh"]

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -12,31 +12,25 @@ then
 fi
 
 watch="false"
-multithreaded="false"
+PARAMS=""
+
 while [[ $# -gt 0 ]]
 do
   arg="$1"
   case $arg in
-    -m|--multithreaded)
-    multithreaded="true"
-    shift
-    ;;
     -w|--watch)
     watch="true"
+    shift
+    ;;
+    *)
+    PARAMS="$PARAMS $1"
     shift
     ;;
   esac
 done
 
-
-if [[ "$multithreaded" == "true" ]]; then
-  args="-Dpreview_mt"
-else
-  args=""
-fi
-
 if [[ "$watch" == "true" ]]; then
-  CRYSTAL_WORKERS=$(nproc) watchexec -e cr -c -r -w src -w spec -- scripts/crystal-spec.sh -v ${args}
+  CRYSTAL_WORKERS=$(nproc) watchexec -e cr -c -r -w src -w spec -- scripts/crystal-spec.sh -v $PARAMS
 else
-  CRYSTAL_WORKERS=$(nproc) scripts/crystal-spec.sh -v ${args}
+  CRYSTAL_WORKERS=$(nproc) scripts/crystal-spec.sh -v $PARAMS
 fi

--- a/spec/api/command_spec.cr
+++ b/spec/api/command_spec.cr
@@ -5,14 +5,14 @@ require "../helper"
 # - Create the call instance
 # - Check the outcome of the request
 
-module PlaceOS::Core
+module PlaceOS::Core::Api
   EXEC_PAYLOAD = {
     __exec__:               "used_for_place_testing",
     used_for_place_testing: [] of String,
   }.to_json
 
-  describe Api::Command, tags: "api" do
-    namespace = Api::Command::NAMESPACE[0]
+  describe Command, tags: "api" do
+    namespace = Command::NAMESPACE[0]
     json_headers = HTTP::Headers{
       "Content-Type" => "application/json",
     }
@@ -30,7 +30,7 @@ module PlaceOS::Core
         ctx = context("POST", route, json_headers, EXEC_PAYLOAD)
         ctx.route_params = {"module_id" => mod_id}
         ctx.response.output = io
-        command_controller = Api::Command.new(ctx, :execute, module_manager)
+        command_controller = Command.new(ctx, :execute, module_manager)
 
         command_controller.execute
 
@@ -59,7 +59,7 @@ module PlaceOS::Core
         route = File.join(namespace, mod_id, "debugger")
         ctx = context("GET", route)
         ctx.route_params = {"module_id" => mod_id}
-        command_controller = Api::Command.new(ctx, :execute, module_manager)
+        command_controller = Command.new(ctx, :execute, module_manager)
 
         # Set up websockets on a blocking bidirectional IO
         io_server, io_client = IO::Stapled.pipe
@@ -91,7 +91,7 @@ module PlaceOS::Core
         route = File.join(namespace, mod_id, "execute")
         ctx = context("POST", route, json_headers, EXEC_PAYLOAD)
         ctx.route_params = {"module_id" => mod_id}
-        Api::Command.new(ctx, :execute, module_manager).execute
+        Command.new(ctx, :execute, module_manager).execute
 
         ctx.response.status_code.should eq 200
 

--- a/spec/api/drivers_spec.cr
+++ b/spec/api/drivers_spec.cr
@@ -1,8 +1,8 @@
 require "../helper"
 
-module PlaceOS::Core
-  describe Api::Drivers, tags: "api" do
-    namespace = Api::Drivers::NAMESPACE[0]
+module PlaceOS::Core::Api
+  describe Drivers, tags: "api" do
+    namespace = Drivers::NAMESPACE[0]
     json_headers = HTTP::Headers{
       "Content-Type" => "application/json",
     }
@@ -14,7 +14,7 @@ module PlaceOS::Core
         path = "#{namespace}?repository=#{repo.folder_name}"
         ctx = context("GET", path, json_headers)
         ctx.response.output = IO::Memory.new
-        Api::Drivers.new(ctx, :index).index
+        Drivers.new(ctx, :index).index
 
         result = begin
           Array(String).from_json(ctx.response.output.to_s)
@@ -45,7 +45,7 @@ module PlaceOS::Core
         ctx = context("GET", path, json_headers)
         ctx.route_params = {"file_name" => uri}
         ctx.response.output = IO::Memory.new
-        Api::Drivers.new(ctx, :compiled).compiled
+        Drivers.new(ctx, :compiled).compiled
 
         ctx.response.status_code.should eq 200
         Bool.from_json(ctx.response.output.to_s).should be_true
@@ -62,7 +62,7 @@ module PlaceOS::Core
         ctx.route_params = {"repository" => directory}
         ctx.response.output = IO::Memory.new
 
-        Api::Drivers.new(ctx, :branches).branches
+        Drivers.new(ctx, :branches).branches
 
         ctx.response.status_code.should eq 404
       end
@@ -74,7 +74,7 @@ module PlaceOS::Core
         ctx = context("GET", path, json_headers)
         ctx.route_params = {"repository" => directory}
         ctx.response.output = IO::Memory.new
-        Api::Drivers.new(ctx, :branches).branches
+        Drivers.new(ctx, :branches).branches
 
         ctx.response.status_code.should eq 200
         branches = Array(String).from_json(ctx.response.output.to_s)
@@ -94,7 +94,7 @@ module PlaceOS::Core
         ctx = context("GET", path, json_headers)
         ctx.route_params = {"file_name" => uri}
         ctx.response.output = IO::Memory.new
-        Api::Drivers.new(ctx, :index).show
+        Drivers.new(ctx, :index).show
 
         ctx.response.status_code.should eq 200
 

--- a/spec/api/root_spec.cr
+++ b/spec/api/root_spec.cr
@@ -1,20 +1,24 @@
 require "../helper"
 
 module PlaceOS::Core::Api
-  describe Root do
-    it "health checks" do
-      ctx = context("GET", "/api/core/v1/")
-      Root.new(ctx, :index).index
-      ctx.response.status_code.should eq 200
+  describe Root, tags: "api" do
+    describe "GET /api/core/v1" do
+      it "health checks" do
+        ctx = context("GET", "/api/core/v1/")
+        Root.new(ctx, :index).index
+        ctx.response.status_code.should eq 200
+      end
     end
 
-    it "should check version" do
-      ctx = context("GET", "/api/core/v1/version")
-      ctx.response.output = IO::Memory.new
-      Root.new(ctx, :version).version
-      ctx.response.status_code.should eq 200
-      version = PlaceOS::Model::Version.from_json(ctx.response.output.to_s)
-      version.service.should eq "core"
+    describe "GET /api/core/v1/version" do
+      it "returns service version" do
+        ctx = context("GET", "/api/core/v1/version")
+        ctx.response.output = IO::Memory.new
+        Root.new(ctx, :version).version
+        ctx.response.status_code.should eq 200
+        version = PlaceOS::Model::Version.from_json(ctx.response.output.to_s)
+        version.service.should eq "core"
+      end
     end
   end
 end

--- a/spec/api/status_spec.cr
+++ b/spec/api/status_spec.cr
@@ -1,8 +1,8 @@
 require "../helper"
 
-module PlaceOS::Core
-  describe Api::Status do
-    namespace = Api::Drivers::NAMESPACE[0]
+module PlaceOS::Core::Api
+  describe Status, tags: "api" do
+    namespace = Status::NAMESPACE[0]
     json_headers = HTTP::Headers{
       "Content-Type" => "application/json",
     }
@@ -17,7 +17,7 @@ module PlaceOS::Core
         io = IO::Memory.new
         ctx = context("GET", namespace, json_headers)
         ctx.response.output = io
-        Api::Status.new(ctx).index
+        Status.new(ctx).index
 
         ctx.response.status_code.should eq 200
 

--- a/spec/mappings/control_system_modules_spec.cr
+++ b/spec/mappings/control_system_modules_spec.cr
@@ -1,6 +1,6 @@
 require "../helper"
 
-module PlaceOS::Core
+module PlaceOS::Core::Mappings
   class Mock < ModuleManager
     FAILS_TO_REFRESH = "fails-to-refresh"
 
@@ -14,12 +14,12 @@ module PlaceOS::Core
     end
   end
 
-  describe Mappings::ControlSystemModules, tags: "resource" do
+  describe ControlSystemModules, tags: "mappings" do
     describe ".update_mapping" do
       it "ignores systems not mapped to node" do
         control_system = Model::Generator.control_system
         control_system.id = DiscoveryMock::DOES_NOT_MAP
-        control_system_modules = Mappings::ControlSystemModules.new(module_manager: module_manager_mock, startup: false)
+        control_system_modules = ControlSystemModules.new(module_manager: module_manager_mock, startup: false)
         control_system_modules.process_resource(:updated, control_system).skipped?.should be_true
       end
 
@@ -50,7 +50,7 @@ module PlaceOS::Core
         storage["device/2"] = device_modules[0].id
         storage["device/3"] = "doesn't exist"
 
-        Mappings::ControlSystemModules.update_mapping(
+        ControlSystemModules.update_mapping(
           cs,
           startup: true,
           module_manager: Mock.new(CORE_URL),
@@ -73,7 +73,7 @@ module PlaceOS::Core
         storage[mock_key] = "foo"
         storage[mock_key].should eq "foo"
 
-        Mappings::ControlSystemModules.set_mappings(cs, nil).should eq({} of String => String)
+        ControlSystemModules.set_mappings(cs, nil).should eq({} of String => String)
         storage[mock_key]?.should be_nil
       end
     end
@@ -82,7 +82,7 @@ module PlaceOS::Core
       it "does not update if system is destroyed" do
         cs = Model::ControlSystem.new
         cs.destroyed = true
-        Mappings::ControlSystemModules.update_logic_modules(cs, module_manager_mock).should eq 0
+        ControlSystemModules.update_logic_modules(cs, module_manager_mock).should eq 0
       end
 
       it "returns the number of refreshed modules" do
@@ -95,13 +95,13 @@ module PlaceOS::Core
           Model::Generator.module(driver, cs)
         end
 
-        Mappings::ControlSystemModules.update_logic_modules(cs, mock_manager).should eq 0
+        ControlSystemModules.update_logic_modules(cs, mock_manager).should eq 0
 
         mods[0].save!
-        Mappings::ControlSystemModules.update_logic_modules(cs, mock_manager).should eq 1
+        ControlSystemModules.update_logic_modules(cs, mock_manager).should eq 1
 
         mods[1].save!
-        Mappings::ControlSystemModules.update_logic_modules(cs, mock_manager).should eq 2
+        ControlSystemModules.update_logic_modules(cs, mock_manager).should eq 2
       end
 
       it "handles refresh failures" do
@@ -111,7 +111,7 @@ module PlaceOS::Core
         mock_manager = Mock.new(CORE_URL)
         okay = Model::Generator.module(driver, cs)
         okay.save!
-        Mappings::ControlSystemModules.update_logic_modules(cs, mock_manager).should eq 1
+        ControlSystemModules.update_logic_modules(cs, mock_manager).should eq 1
 
         fails = Model::Generator.module(driver, cs)
         fails._new_flag = true
@@ -119,12 +119,12 @@ module PlaceOS::Core
         fails.save!
 
         # Updated the sole good module
-        Mappings::ControlSystemModules.update_logic_modules(cs, mock_manager).should eq 1
+        ControlSystemModules.update_logic_modules(cs, mock_manager).should eq 1
 
         okay.destroy
 
         # No modules to update
-        Mappings::ControlSystemModules.update_logic_modules(cs, mock_manager).should eq 0
+        ControlSystemModules.update_logic_modules(cs, mock_manager).should eq 0
       end
     end
   end

--- a/spec/mappings/module_names_spec.cr
+++ b/spec/mappings/module_names_spec.cr
@@ -1,7 +1,7 @@
 require "../helper"
 
 module PlaceOS::Core::Mappings
-  describe ModuleNames, tags: "resource" do
+  describe ModuleNames, tags: "mappings" do
     it "ignores creates" do
       mod = Model::Module.new
       ModuleNames.new(ModuleManager.new("https://test.online"))

--- a/spec/module_manager_spec.cr
+++ b/spec/module_manager_spec.cr
@@ -1,7 +1,7 @@
 require "./helper"
 
 module PlaceOS::Core
-  describe ModuleManager do
+  describe ModuleManager, tags: "processes" do
     describe "edge" do
     end
 

--- a/spec/placeos-edge/client_spec.cr
+++ b/spec/placeos-edge/client_spec.cr
@@ -1,7 +1,7 @@
 require "./helper"
 
 module PlaceOS::Edge
-  describe Client do
+  describe Client, tags: ["api", "edge"] do
     it "handshakes on register" do
       coordination = Channel(Bool).new
 

--- a/spec/processes/edge_spec.cr
+++ b/spec/processes/edge_spec.cr
@@ -49,7 +49,7 @@ module PlaceOS::Core::ProcessManager
     end
   end
 
-  describe Edge do
+  describe Edge, tags: ["edge", "processes"] do
     it "debug" do
       with_edge do |ctx, _client, pm|
         module_id = ctx.module.id.as(String)

--- a/spec/processes/local_spec.cr
+++ b/spec/processes/local_spec.cr
@@ -15,7 +15,7 @@ module PlaceOS::Core::ProcessManager
     manager.loaded_modules.should eq({driver_key => [module_id]})
   end
 
-  describe Local do
+  describe Local, tags: "processes" do
     with_driver do |mod, driver_path, driver_key, _driver|
       describe Local::Common do
         describe "driver_loaded?" do

--- a/test
+++ b/test
@@ -18,7 +18,7 @@ docker-compose build
 
 exit_code="0"
 
-docker-compose run --rm test /app/scripts/entrypoint.sh "$@" || exit_code="$?"
+docker-compose run --rm test $@ || exit_code="$?"
 
 docker-compose down
 


### PR DESCRIPTION
This is unfortunately necessary because we're hitting the Github Action Runners memory limit.

This change should be considered temporary until the spec's memory usage can be minimised.