### PR TITLE
build: update `crystal-etcd`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
     hostname: rethink
 
   etcd:
-    image: bitnami/etcd:${ETCD_VERSION:-3.3.12}
+    image: bitnami/etcd:${ETCD_VERSION:-3.5.1}
     restart: always
     hostname: etcd
     environment:

--- a/shard.lock
+++ b/shard.lock
@@ -54,7 +54,7 @@ shards:
 
   etcd:
     git: https://github.com/place-labs/crystal-etcd.git
-    version: 1.2.4
+    version: 1.2.5
 
   exec_from:
     git: https://github.com/place-labs/exec_from.git

--- a/src/core-app.cr
+++ b/src/core-app.cr
@@ -72,6 +72,9 @@ Signal::INT.trap &terminate
 # Docker containers use the term signal
 Signal::TERM.trap &terminate
 
+# Wait for etcd, redis, and rethinkdb to be ready
+PlaceOS::Core.wait_for_resources
+
 spawn(same_thread: true) do
   begin
     PlaceOS::Core.start_managers

--- a/src/placeos-core/healthcheck.cr
+++ b/src/placeos-core/healthcheck.cr
@@ -1,0 +1,46 @@
+require "promise"
+require "rethinkdb"
+require "rethinkdb-orm"
+
+module PlaceOS::Core::Healthcheck
+  def self.healthcheck? : Bool
+    Promise.all(
+      Promise.defer {
+        check_resource?("redis") { ::PlaceOS::Driver::RedisStorage.with_redis &.ping }
+      },
+      Promise.defer {
+        check_resource?("etcd") { ModuleManager.instance.discovery.etcd(&.maintenance.status) }
+      },
+      Promise.defer {
+        check_resource?("rethinkdb") { rethinkdb_healthcheck }
+      },
+    ).then(&.all?).get
+  end
+
+  private def self.check_resource?(resource)
+    Log.trace { "healthchecking #{resource}" }
+    !!yield
+  rescue exception
+    Log.error(exception: exception) { {"connection check to #{resource} failed"} }
+    false
+  end
+
+  private class_getter rethinkdb_admin_connection : RethinkDB::Connection do
+    RethinkDB.connect(
+      host: RethinkORM.settings.host,
+      port: RethinkORM.settings.port,
+      db: "rethinkdb",
+      user: RethinkORM.settings.user,
+      password: RethinkORM.settings.password,
+      max_retry_attempts: 1,
+    )
+  end
+
+  private def self.rethinkdb_healthcheck
+    RethinkDB
+      .table("server_status")
+      .pluck("id", "name")
+      .run(rethinkdb_admin_connection)
+      .first?
+  end
+end


### PR DESCRIPTION
- Updates `crystal-etcd` to fix an issue with etcd > `3.3`
- Adds a check at startup that all upstream services are available