### PR TITLE
fix(process_manager/common): should propagate RemoteExceptions

### DIFF
--- a/src/placeos-core/process_manager/common.cr
+++ b/src/placeos-core/process_manager/common.cr
@@ -11,6 +11,8 @@ module PlaceOS::Core::ProcessManager::Common
       request_body,
       user_id: user_id,
     )
+  rescue error : PlaceOS::Driver::RemoteException
+    raise error
   rescue exception
     raise module_error(module_id, exception)
   end


### PR DESCRIPTION
was catching all exceptions however this one is expected and handled upstream in the controller