### PR TITLE
fix(edge): resolve `crystal binary in the environment` error

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -159,7 +159,7 @@ shards:
 
   placeos-compiler:
     git: https://github.com/placeos/compiler.git
-    version: 4.9.1
+    version: 4.9.2
 
   placeos-core-client:
     git: https://github.com/placeos/core-client.git
@@ -175,7 +175,7 @@ shards:
 
   placeos-models:
     git: https://github.com/placeos/models.git
-    version: 8.4.0
+    version: 8.4.1
 
   placeos-resource:
     git: https://github.com/place-labs/resource.git

--- a/src/placeos-core/process_manager/common.cr
+++ b/src/placeos-core/process_manager/common.cr
@@ -1,3 +1,6 @@
+require "hardware"
+require "placeos-compiler/compiler"
+
 # Methods for interacting with module processes common across a local and edge node
 module PlaceOS::Core::ProcessManager::Common
   def execute(module_id : String, payload : String | IO, user_id : String?)

--- a/src/placeos-edge/client.cr
+++ b/src/placeos-edge/client.cr
@@ -4,7 +4,7 @@ require "uri"
 
 require "placeos-driver/protocol/management"
 
-require "../placeos-core/process_manager/local"
+require "../placeos-core/process_manager/common"
 
 require "./constants"
 require "./protocol"
@@ -12,7 +12,7 @@ require "./transport"
 
 module PlaceOS::Edge
   class Client
-    include Core::ProcessManager::Local::Common
+    include Core::ProcessManager::Common
 
     Log                = ::Log.for(self)
     WEBSOCKET_API_PATH = "/api/engine/v2/edges/control"


### PR DESCRIPTION
**Description of the change**

Update to `placeos-compiler` to turn the check into a lazy one.

**Benefits**

Edge app can start now.

**Possible drawbacks**

May delay the failure of a core without crystal in the environment, but realistically this will never happen