### PR TITLE
fix(edge): use correct api-key param and update key validation 

### DIFF
--- a/spec/placeos-edge/client_spec.cr
+++ b/spec/placeos-edge/client_spec.cr
@@ -9,19 +9,19 @@ module PlaceOS::Edge
       client_ws, server_ws = mock_sockets
 
       spawn {
-        client.connect(client_ws) do
+        client.connect do
           coordination.send(true)
         end
       }
 
       messages = Channel(Protocol::Text).new
 
-      server_ws.on_message do |m|
-        messages.send Protocol::Text.from_json(m)
-        server_ws.send(Protocol::Text.new(0_u64, Protocol::Message::RegisterResponse.new(true)).to_json)
-      end
+      # server_ws.on_message do |m|
+      #   messages.send Protocol::Text.from_json(m)
+      #   server_ws.send(Protocol::Text.new(0_u64, Protocol::Message::RegisterResponse.new(true)).to_json)
+      # end
 
-      spawn { server_ws.run }
+      # spawn { server_ws.run }
 
       Fiber.yield
 

--- a/spec/placeos-edge/client_spec.cr
+++ b/spec/placeos-edge/client_spec.cr
@@ -9,19 +9,19 @@ module PlaceOS::Edge
       client_ws, server_ws = mock_sockets
 
       spawn {
-        client.connect do
+        client.connect(client_ws) do
           coordination.send(true)
         end
       }
 
       messages = Channel(Protocol::Text).new
 
-      # server_ws.on_message do |m|
-      #   messages.send Protocol::Text.from_json(m)
-      #   server_ws.send(Protocol::Text.new(0_u64, Protocol::Message::RegisterResponse.new(true)).to_json)
-      # end
+      server_ws.on_message do |m|
+        messages.send Protocol::Text.from_json(m)
+        server_ws.send(Protocol::Text.new(0_u64, Protocol::Message::RegisterResponse.new(true)).to_json)
+      end
 
-      # spawn { server_ws.run }
+      spawn { server_ws.run }
 
       Fiber.yield
 

--- a/src/placeos-edge/client.cr
+++ b/src/placeos-edge/client.cr
@@ -52,8 +52,6 @@ module PlaceOS::Edge
       uri = uri.dup
       uri.path = WEBSOCKET_API_PATH
       uri.query = "api-key=#{@secret}"
-      Log.info {"URI IS:"}
-      Log.info {uri.inspect}
       @uri = uri
     end
 

--- a/src/placeos-edge/client.cr
+++ b/src/placeos-edge/client.cr
@@ -51,7 +51,7 @@ module PlaceOS::Edge
       # Mutate a copy as secret is embedded in uri
       uri = uri.dup
       uri.path = WEBSOCKET_API_PATH
-      uri.query = "token=#{secret}"
+      uri.query = "api-key=#{@secret}"
       @uri = uri
     end
 

--- a/src/placeos-edge/client.cr
+++ b/src/placeos-edge/client.cr
@@ -52,6 +52,8 @@ module PlaceOS::Edge
       uri = uri.dup
       uri.path = WEBSOCKET_API_PATH
       uri.query = "api-key=#{@secret}"
+      Log.info {"URI IS:"}
+      Log.info {uri.inspect}
       @uri = uri
     end
 

--- a/src/placeos-edge/constants.cr
+++ b/src/placeos-edge/constants.cr
@@ -15,7 +15,7 @@ module PlaceOS::Edge
   LOG_STDOUT = ActionController.default_backend
   Log        = ::Log.for(self)
 
-  ID_LENGTH = 32
+  ID_LENGTH   = 32
   HASH_LENGTH = 43
 
   def self.production?

--- a/src/placeos-edge/constants.cr
+++ b/src/placeos-edge/constants.cr
@@ -20,9 +20,14 @@ module PlaceOS::Edge
   end
 
   protected def self.decode_token(token)
-    String.new(Base64.decode(token)) if token.presence
-  rescue
-    Log.error { "malformed token" }
+    # Token is in the form hash.secret so validate the two parts best we can
+    # Using string length is a bit shit but not sure how else we can do
+    parts = token.split(".")
+    raise "malformed Token" if parts[0].size != 32
+    raise "malformed Token" if parts[1].size != 43
+    token if token.presence
+  rescue ex
+    Log.error { ex.message }
     nil
   end
 end

--- a/src/placeos-edge/constants.cr
+++ b/src/placeos-edge/constants.cr
@@ -8,7 +8,7 @@ module PlaceOS::Edge
   CLIENT_SECRET = ENV["PLACE_EDGE_KEY"]?.try { |t| decode_token(t) } || (production? ? abort("missing PLACE_EDGE_KEY in environment") : "edge-1000_secret")
 
   # URI of PlaceOS instance
-  PLACE_URI = URI.parse(ENV["PLACE_URI"]? || "https://localhost:8443".tap { |v| Log.warn { "missing PLACE_URI in environment, using #{v}" } })
+  PLACE_URI = URI.parse(ENV["PLACE_URI"]? || "http://localhost:6000".tap { |v| Log.warn { "missing PLACE_URI in environment, using #{v}" } })
 
   PROD = ENV["SG_ENV"]? == "production"
 

--- a/src/placeos-edge/constants.cr
+++ b/src/placeos-edge/constants.cr
@@ -5,31 +5,17 @@ module PlaceOS::Edge
   VERSION  = {{ `shards version "#{__DIR__}"`.chomp.stringify.downcase }}
 
   # Secret used to register with PlaceOS
-  CLIENT_SECRET = ENV["PLACE_EDGE_KEY"]?.try { |t| decode_token(t) } || (production? ? abort("missing PLACE_EDGE_KEY in environment") : "edge-1000_secret")
+  CLIENT_SECRET = ENV["PLACE_EDGE_KEY"]? || (production? ? abort("missing PLACE_EDGE_KEY in environment") : "edge-1000_secret")
 
   # URI of PlaceOS instance
-  PLACE_URI = URI.parse(ENV["PLACE_URI"]? || "http://localhost:6000".tap { |v| Log.warn { "missing PLACE_URI in environment, using #{v}" } })
+  PLACE_URI = URI.parse(ENV["PLACE_URI"]? || "https://localhost:8443".tap { |v| Log.warn { "missing PLACE_URI in environment, using #{v}" } })
 
   PROD = ENV["SG_ENV"]? == "production"
 
   LOG_STDOUT = ActionController.default_backend
   Log        = ::Log.for(self)
 
-  ID_LENGTH   = 32
-  HASH_LENGTH = 43
-
   def self.production?
     PROD
-  end
-
-  protected def self.decode_token(token)
-    # Token is in the form hash.secret so validate the two parts best we can
-    # Using string length is a bit shit but not sure how else we can do
-    id, hash = token.split(".", 2)
-    raise "malformed Token" if id.size != ID_LENGTH || hash.size != HASH_LENGTH
-    token if token.presence
-  rescue ex
-    Log.error { ex.message }
-    nil
   end
 end

--- a/src/placeos-edge/constants.cr
+++ b/src/placeos-edge/constants.cr
@@ -15,6 +15,9 @@ module PlaceOS::Edge
   LOG_STDOUT = ActionController.default_backend
   Log        = ::Log.for(self)
 
+  ID_LENGTH = 32
+  HASH_LENGTH = 43
+
   def self.production?
     PROD
   end
@@ -22,9 +25,8 @@ module PlaceOS::Edge
   protected def self.decode_token(token)
     # Token is in the form hash.secret so validate the two parts best we can
     # Using string length is a bit shit but not sure how else we can do
-    parts = token.split(".")
-    raise "malformed Token" if parts[0].size != 32
-    raise "malformed Token" if parts[1].size != 43
+    id, hash = token.split(".", 2)
+    raise "malformed Token" if id.size != ID_LENGTH || hash.size != HASH_LENGTH
     token if token.presence
   rescue ex
     Log.error { ex.message }


### PR DESCRIPTION
**Description of the change**

Ensure the edge client is using the right param for api-key authentication and that parts of the api key are the correct length.

**Benefits**

Edge client can successfully auth a ws connection against the edge control endpoint.

**Possible drawbacks**

ID or hash length could change in the api key making validation fail.