### PR TITLE
fix(control_system_modules): update system references in modules

### DIFF
--- a/src/placeos-core/mappings/control_system_modules.cr
+++ b/src/placeos-core/mappings/control_system_modules.cr
@@ -64,6 +64,8 @@ module PlaceOS::Core
       updated_modules = Model::Module.logic_for(control_system_id).sum do |mod|
         total += 1
         begin
+          # ensure module has the latest version of the control system model
+          mod.control_system = system
           module_manager.refresh_module(mod)
           Log.debug { {message: "#{mod.running_was == false ? "started" : "updated"} system logic module", module_id: mod.id, control_system_id: control_system_id} }
           1

--- a/src/placeos-core/mappings/control_system_modules.cr
+++ b/src/placeos-core/mappings/control_system_modules.cr
@@ -69,7 +69,6 @@ module PlaceOS::Core
         total += 1
         begin
           # ensure module has the latest version of the control system model
-          Log.warn { "\n\nUPDATING LOGIC: #{mod.id}" }
           mod.control_system = system
           module_manager.refresh_module(mod)
           Log.debug { {message: "#{mod.running_was == false ? "started" : "updated"} system logic module", module_id: mod.id, control_system_id: control_system_id} }

--- a/src/placeos-core/mappings/control_system_modules.cr
+++ b/src/placeos-core/mappings/control_system_modules.cr
@@ -30,8 +30,6 @@ module PlaceOS::Core
       startup : Bool = false,
       module_manager : ModuleManager = ModuleManager.instance
     ) : Resource::Result
-      Log.warn { "\n\nUPDATING SYSTEM: #{system.display_name}" }
-
       relevant_node = startup || module_manager.discovery.own_node?(system.id.as(String))
       unless relevant_node
         return update_logic_modules(system, module_manager) > 0 ? Resource::Result::Success : Resource::Result::Skipped
@@ -66,10 +64,12 @@ module PlaceOS::Core
       control_system_id = system.id.as(String)
       total = 0
       updated_modules = Model::Module.logic_for(control_system_id).sum do |mod|
+        next 0 unless module_manager.discovery.own_node?(mod.id.as(String))
+
         total += 1
         begin
           # ensure module has the latest version of the control system model
-          Log.warn { "UPDATING LOGIC: #{mod.id}" }
+          Log.warn { "\n\nUPDATING LOGIC: #{mod.id}" }
           mod.control_system = system
           module_manager.refresh_module(mod)
           Log.debug { {message: "#{mod.running_was == false ? "started" : "updated"} system logic module", module_id: mod.id, control_system_id: control_system_id} }

--- a/src/placeos-core/module_manager.cr
+++ b/src/placeos-core/module_manager.cr
@@ -381,6 +381,7 @@ module PlaceOS::Core
       payload = mod.to_json.rchop
 
       # The settings object needs to be unescaped
+      Log.warn { "\n\nUPDATING SETTINGS for #{mod.id} on #{mod.control_system.display_name}\n\n" }
       %(#{payload},"control_system":#{mod.control_system.to_json},"settings":#{merged_settings}})
     end
 

--- a/src/placeos-core/module_manager.cr
+++ b/src/placeos-core/module_manager.cr
@@ -381,7 +381,6 @@ module PlaceOS::Core
       payload = mod.to_json.rchop
 
       # The settings object needs to be unescaped
-      Log.warn { "\n\nUPDATING SETTINGS for #{mod.id} on #{mod.control_system.try &.display_name}\n\n" }
       %(#{payload},"control_system":#{mod.control_system.to_json},"settings":#{merged_settings}})
     end
 

--- a/src/placeos-core/module_manager.cr
+++ b/src/placeos-core/module_manager.cr
@@ -381,7 +381,7 @@ module PlaceOS::Core
       payload = mod.to_json.rchop
 
       # The settings object needs to be unescaped
-      Log.warn { "\n\nUPDATING SETTINGS for #{mod.id} on #{mod.control_system.display_name}\n\n" }
+      Log.warn { "\n\nUPDATING SETTINGS for #{mod.id} on #{mod.control_system.try &.display_name}\n\n" }
       %(#{payload},"control_system":#{mod.control_system.to_json},"settings":#{merged_settings}})
     end
 


### PR DESCRIPTION
related to comments in #212 but not a fix for that issue

This pull does two things:

1. ensures the module state is updated with the latest version of the control system module
2. updates module state on cores that are not managing the system module mappings / lookup tables