### PR TITLE
feat(module_manager): periodically check that processes are alive

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -261,6 +261,10 @@ shards:
     git: https://github.com/wyhaines/time-ext.cr.git
     version: 0.1.0+git.commit.175f658235fb6cdc9c804cb96da510fec27f4cd6
 
+  timeout:
+    git: https://github.com/wyhaines/timeout.cr.git
+    version: 0.1.0+git.commit.130d8893f5222ebaed06f743a3bdad7f6b2a7be7
+
   tokenizer:
     git: https://github.com/spider-gazelle/tokenizer.git
     version: 1.1.1

--- a/shard.yml
+++ b/shard.yml
@@ -83,6 +83,9 @@ dependencies:
     github: spider-gazelle/secrets-env
     version: ~> 1
 
+  tasker:
+    github: spider-gazelle/tasker
+
   git-repository:
     github: place-labs/git-repository
 

--- a/shard.yml
+++ b/shard.yml
@@ -86,8 +86,8 @@ dependencies:
   tasker:
     github: spider-gazelle/tasker
 
-  git-repository:
-    github: place-labs/git-repository
+  timeout:
+    github: wyhaines/timeout.cr
 
 development_dependencies:
   ameba:

--- a/spec/api/command_spec.cr
+++ b/spec/api/command_spec.cr
@@ -105,7 +105,7 @@ module PlaceOS::Core::Api
           end
         end
 
-        messages.should contain "this will be propagated to backoffice!"
+        messages.should contain %([1,"this will be propagated to backoffice!"])
       ensure
         resource_manager.try &.stop
       end

--- a/spec/processes/local_spec.cr
+++ b/spec/processes/local_spec.cr
@@ -75,12 +75,11 @@ module PlaceOS::Core::ProcessManager
             when message = message_channel.receive
               messages << message
             when timeout 2.seconds
-              fail "timed out waiting for debug output"
+              break
             end
           end
 
           messages.should contain %([1,"hello"])
-          messages.should contain %([1,"status updated: connected = true"])
         end
 
         it "ignore" do
@@ -106,12 +105,11 @@ module PlaceOS::Core::ProcessManager
             when message = message_channel.receive
               messages << message
             when timeout 2.seconds
-              fail "timed out waiting for debug output"
+              break
             end
           end
 
           messages.should contain %([1,"hello"])
-          messages.should contain %([1,"status updated: connected = true"])
 
           pm.ignore(module_id, &callback)
 

--- a/src/constants.cr
+++ b/src/constants.cr
@@ -28,5 +28,6 @@ module PlaceOS::Core
   class_getter? production : Bool = PROD
 
   # Used in `ModuleManager`
-  PROCESS_CHECK_PERIOD = (ENV["PLACE_CORE_PROCESS_CHECK_PERIOD"]?.try(&.to_i?) || 45).seconds
+  PROCESS_CHECK_PERIOD  = (ENV["PLACE_CORE_PROCESS_CHECK_PERIOD"]?.try(&.to_i?) || 45).seconds
+  PROCESS_COMMS_TIMEOUT = (ENV["PLACE_CORE_PROCESS_COMMS_TIMEOUT"]?.try(&.to_i?) || 20)
 end

--- a/src/constants.cr
+++ b/src/constants.cr
@@ -25,8 +25,6 @@ module PlaceOS::Core
 
   RESPONSE_CODE_HEADER = "Response-Code"
 
-  # Process check period
-
   class_getter? production : Bool = PROD
 
   # Used in `ModuleManager`

--- a/src/constants.cr
+++ b/src/constants.cr
@@ -25,5 +25,10 @@ module PlaceOS::Core
 
   RESPONSE_CODE_HEADER = "Response-Code"
 
+  # Process check period
+
   class_getter? production : Bool = PROD
+
+  # Used in `ModuleManager`
+  PROCESS_CHECK_PERIOD = (ENV["PLACE_CORE_PROCESS_CHECK_PERIOD"]?.try(&.to_i?) || 45).seconds
 end

--- a/src/placeos-core/module_manager.cr
+++ b/src/placeos-core/module_manager.cr
@@ -423,9 +423,9 @@ module PlaceOS::Core
           end
 
           unless process_alive
-            # Fire off a terminate request
+            # Ensure the process is dead.
             begin
-              protocol_manager.terminate
+              Process.signal(Signal::KILL, protocol_manager.pid)
             rescue
             end
 

--- a/src/placeos-core/process_check.cr
+++ b/src/placeos-core/process_check.cr
@@ -1,0 +1,79 @@
+require "tasker"
+require "timeout"
+
+require "../constants"
+
+module PlaceOS::Core
+  # Periodic Process Check
+  module ProcessCheck
+    @process_check_task : Tasker::Repeat(Nil)?
+
+    # Begin scanning for dead driver processes
+    protected def start_process_check
+      @process_check_task = Tasker.every(PROCESS_CHECK_PERIOD) do
+        process_check
+      end
+    end
+
+    protected def stop_process_check
+      @process_check_task.try &.cancel
+    end
+
+    # TODO:
+    # Add `with_module_managers` to ProcessManager interface
+    # and thus provide process check support for edge nodes.
+    #
+    # NOTE: This could also be performed independently in the `Edge::Client` instead of here.
+    protected def process_check : Nil
+      Log.debug { "checking for dead driver processes" }
+
+      # NOTE: Add `edge_processes` here once it supports process check
+      {local_processes}.each &.with_module_managers do |module_manager_map|
+        # Group module keys by protcol manager
+        grouped_managers = module_manager_map.each_with_object({} of Driver::Protocol::Management => Array(String)) do |(module_id, protocol_manager), grouped|
+          (grouped[protocol_manager] ||= [] of String) << module_id
+        end
+
+        # Check if any processes are dead
+        grouped_managers.each do |protocol_manager, module_ids|
+          # Asynchronously check if any processes are timing out on comms, and if so, restart them
+          spawn(same_thread: true) do
+            process_alive = begin
+              # If there's an empty response, the modules that were meant to be running are not.
+              # This is taken as a sign that the process is dead.
+              # Alternatively, if the response times out, the process is dead.
+              timeout(PROCESS_COMMS_TIMEOUT) do
+                !protocol_manager.info.empty?
+              end
+            rescue error
+              Log.warn(exception: error) { "unresponsive process manager for #{module_ids.join(", ")}" }
+              false
+            end
+
+            unless process_alive
+              Log.warn { {message: "restarting unresponsive driver", driver_path: protocol_manager.@driver_path} }
+              # Ensure the process is dead.
+              begin
+                Process.signal(Signal::KILL, protocol_manager.pid)
+              rescue
+              end
+
+              # Remove the dead manager from the map
+              module_manager_map.reject(module_ids)
+
+              # Restart all the modules previously assigned to the dead manager
+              #
+              # TODO:
+              # Make this independent of a database query by using the dead manager's stored module_ids and payloads.
+              # This will allow this module to be included in `PlaceOS::Edge::Client`.
+              # To do so, one will need to create the module manager (currently done by the `load_module` below (which is in `PlaceOS::Core::ModuleManager`))
+              Model::Module.find_all(module_ids).each do |mod|
+                load_module(mod)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/placeos-core/process_manager/common.cr
+++ b/src/placeos-core/process_manager/common.cr
@@ -212,6 +212,12 @@ module PlaceOS::Core::ProcessManager::Common
   # Mapping from driver path to protocol manager
   @driver_protocol_managers : Hash(String, Driver::Protocol::Management) = {} of String => Driver::Protocol::Management
 
+  protected def with_module_managers(&block)
+    protocol_manager_lock.synchronize do
+      yield @module_protocol_managers
+    end
+  end
+
   protected def protocol_manager_by_module?(module_id) : Driver::Protocol::Management?
     manager_by_key?(module_id, @module_protocol_managers)
   end


### PR DESCRIPTION
Checks that drivers are responsive to comms periodically, and if they're not, it kills them and reloads all assigned modules.

Comes with two new environment variables...
- `PLACE_CORE_PROCESS_CHECK_PERIOD`: How often to check for dead processes
- `PLACE_CORE_PROCESS_COMMS_TIMEOUT`: How long to wait before assuming the driver's comms are borked 