### PR TITLE
fix: ignore empty module

### DIFF
--- a/src/placeos-core/process_check.cr
+++ b/src/placeos-core/process_check.cr
@@ -58,11 +58,16 @@ module PlaceOS::Core
               # If there's an empty response, the modules that were meant to be running are not.
               # This is taken as a sign that the process is dead.
               # Alternatively, if the response times out, the process is dead.
+              info = nil
               timeout(PROCESS_COMMS_TIMEOUT) do
-                protocol_manager.info
+                info = protocol_manager.info
               end
 
-              State::Running
+              if info.nil? || info.as(Array(String)).empty?
+                State::Dead
+              else
+                State::Running
+              end
             rescue error : Timeout::Error
               Log.warn(exception: error) { "unresponsive process manager for #{module_ids.join(", ")}" }
               State::Unresponsive

--- a/src/placeos-core/process_check.cr
+++ b/src/placeos-core/process_check.cr
@@ -59,11 +59,7 @@ module PlaceOS::Core
               # This is taken as a sign that the process is dead.
               # Alternatively, if the response times out, the process is dead.
               timeout(PROCESS_COMMS_TIMEOUT) do
-                if protocol_manager.info.empty?
-                  State::Dead
-                else
-                  State::Running
-                end
+                State::Running if protocol_manager.info
               end
             rescue error : Timeout::Error
               Log.warn(exception: error) { "unresponsive process manager for #{module_ids.join(", ")}" }

--- a/src/placeos-core/process_check.cr
+++ b/src/placeos-core/process_check.cr
@@ -59,14 +59,16 @@ module PlaceOS::Core
               # This is taken as a sign that the process is dead.
               # Alternatively, if the response times out, the process is dead.
               timeout(PROCESS_COMMS_TIMEOUT) do
-                State::Running if protocol_manager.info
+                protocol_manager.info
               end
+
+              State::Running
             rescue error : Timeout::Error
               Log.warn(exception: error) { "unresponsive process manager for #{module_ids.join(", ")}" }
               State::Unresponsive
             end
 
-            checks.send({state.as(State), {protocol_manager, module_ids}})
+            checks.send({state, {protocol_manager, module_ids}})
           end
         end
 


### PR DESCRIPTION
**Description of the change**

- Gets rid of a cast introduced by timeout shard
- Ignore empty module state