### PR TITLE
fix: handle driver `module_name` changes in module mappings

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -185,9 +185,9 @@ shards:
     git: https://github.com/place-labs/log-backend.git
     version: 0.11.2
 
-  placeos-models:
+  placeos-models: # Overridden
     git: https://github.com/placeos/models.git
-    version: 8.11.3
+    version: 8.11.3+git.commit.6c80506edf0e8faa93f47dbf11fb388de26d347a
 
   placeos-resource:
     git: https://github.com/place-labs/resource.git

--- a/shard.lock
+++ b/shard.lock
@@ -185,9 +185,9 @@ shards:
     git: https://github.com/place-labs/log-backend.git
     version: 0.11.2
 
-  placeos-models: # Overridden
+  placeos-models:
     git: https://github.com/placeos/models.git
-    version: 8.11.3+git.commit.6c80506edf0e8faa93f47dbf11fb388de26d347a
+    version: 8.12.0
 
   placeos-resource:
     git: https://github.com/place-labs/resource.git

--- a/shard.override.yml
+++ b/shard.override.yml
@@ -1,8 +1,4 @@
 dependencies:
-  placeos-models:
-    github: placeos/models
-    branch: feat/resolved-name-changed
-
   pars:
     github: spider-gazelle/pars
 

--- a/shard.override.yml
+++ b/shard.override.yml
@@ -1,6 +1,11 @@
 dependencies:
+  placeos-models:
+    github: placeos/models
+    branch: feat/resolved-name-changed
+
   pars:
     github: spider-gazelle/pars
+
   opentelemetry-instrumentation:
     github: wyhaines/opentelemetry-instrumentation.cr
     branch: main

--- a/spec/mappings/driver_module_names_spec.cr
+++ b/spec/mappings/driver_module_names_spec.cr
@@ -1,20 +1,20 @@
 require "../helper"
 
 module PlaceOS::Core::Mappings
-  describe DriverModuleNames, tags: "mappings", focus: true do
+  describe DriverModuleNames, tags: "mappings" do
     it "updates `module_names` of associated modules" do
-      driver = Generator.driver.save!
-      Generator.module(driver: driver).save!
+      driver = Model::Generator.driver.save!
+      Model::Generator.module(driver: driver).save!
 
       updated = "updated_module_name-#{random_id}"
-      driver.module_name = updated
+      driver.update_fields(module_name: updated)
 
       DriverModuleNames.new
         .process_resource(:updated, driver)
         .success?
         .should be_true
 
-      driver.modules.all? { |m| m.module_name == updated }.should be_true
+      driver.modules.all? { |m| m.name == updated }.should be_true
     end
 
     it "ignores creates" do
@@ -27,7 +27,7 @@ module PlaceOS::Core::Mappings
 
     it "ignores deletes" do
       driver = Model::Driver.new
-      ModuleNames.new
+      DriverModuleNames.new
         .process_resource(:deleted, driver)
         .skipped?
         .should be_true

--- a/spec/mappings/driver_module_names_spec.cr
+++ b/spec/mappings/driver_module_names_spec.cr
@@ -7,7 +7,8 @@ module PlaceOS::Core::Mappings
       Model::Generator.module(driver: driver).save!
 
       updated = "updated_module_name-#{random_id}"
-      driver.update_fields(module_name: updated)
+      driver.module_name = updated
+      driver.module_name_will_change!
 
       DriverModuleNames.new
         .process_resource(:updated, driver)

--- a/spec/mappings/driver_module_names_spec.cr
+++ b/spec/mappings/driver_module_names_spec.cr
@@ -1,0 +1,36 @@
+require "../helper"
+
+module PlaceOS::Core::Mappings
+  describe DriverModuleNames, tags: "mappings", focus: true do
+    it "updates `module_names` of associated modules" do
+      driver = Generator.driver.save!
+      Generator.module(driver: driver).save!
+
+      updated = "updated_module_name-#{random_id}"
+      driver.module_name = updated
+
+      DriverModuleNames.new
+        .process_resource(:updated, driver)
+        .success?
+        .should be_true
+
+      driver.modules.all? { |m| m.module_name == updated }.should be_true
+    end
+
+    it "ignores creates" do
+      driver = Model::Driver.new
+      DriverModuleNames.new
+        .process_resource(:created, driver)
+        .skipped?
+        .should be_true
+    end
+
+    it "ignores deletes" do
+      driver = Model::Driver.new
+      ModuleNames.new
+        .process_resource(:deleted, driver)
+        .skipped?
+        .should be_true
+    end
+  end
+end

--- a/src/placeos-core/cloning.cr
+++ b/src/placeos-core/cloning.cr
@@ -22,7 +22,7 @@ module PlaceOS
       super()
     end
 
-    def process_resource(action : RethinkORM::Changefeed::Event, resource repository : PlaceOS::Model::Repository) : Resource::Result
+    def process_resource(action : Resource::Action, resource repository : PlaceOS::Model::Repository) : Resource::Result
       # Ignore interface repositories
       return Result::Skipped if repository.repo_type.interface?
 

--- a/src/placeos-core/mappings/control_system_modules.cr
+++ b/src/placeos-core/mappings/control_system_modules.cr
@@ -17,7 +17,7 @@ module PlaceOS::Core
       super()
     end
 
-    def process_resource(action : RethinkORM::Changefeed::Event, resource control_system : PlaceOS::Model::ControlSystem) : Resource::Result
+    def process_resource(action : Resource::Action, resource control_system : PlaceOS::Model::ControlSystem) : Resource::Result
       ControlSystemModules.update_mapping(control_system, startup?, module_manager)
     rescue exception
       Log.error(exception: exception) { {message: "while updating mapping for system"} }

--- a/src/placeos-core/mappings/driver_module_names.cr
+++ b/src/placeos-core/mappings/driver_module_names.cr
@@ -1,0 +1,31 @@
+require "placeos-resource"
+require "placeos-models/driver"
+
+module PlaceOS::Core
+  class Mappings::DriverModuleNames < Resource(Model::Driver)
+    def process_resource(action : Resource::Action, resource driver : Model::Driver) : Resource::Result
+      return Resource::Result::Skipped unless action.updated?
+
+      DriverModuleNames.update_module_names(driver)
+    rescue exception
+      Log.error(exception: exception) { {message: "while updating `module_name` for driver modules", name: driver.module_name} }
+      raise Resource::ProcessingError.new(mod.name, exception.message, cause: exception)
+    end
+
+    def self.update_module_names(
+      driver : Model::Driver,
+    )
+      # Only consider `module_name` change events
+      return Resource::Result::Skipped unless driver.resolved_name_changed?
+
+      # Update the `module_name` field across all associated modules
+      driver.modules.each do |mod|
+        mod.update_fields(
+          module_name: driver.module_name,
+        )
+      end
+
+      Resource::Result::Success
+    end
+  end
+end

--- a/src/placeos-core/mappings/driver_module_names.cr
+++ b/src/placeos-core/mappings/driver_module_names.cr
@@ -12,17 +12,13 @@ module PlaceOS::Core
       raise Resource::ProcessingError.new(driver.module_name, exception.message, cause: exception)
     end
 
-    def self.update_module_names(
-      driver : Model::Driver,
-    )
+    def self.update_module_names(driver : Model::Driver)
       # Only consider `module_name` change events
       return Resource::Result::Skipped unless driver.module_name_changed?
 
       # Update the `module_name` field across all associated modules
-      driver.modules.each do |mod|
-        mod.update_fields(
-          name: driver.module_name,
-        )
+      Model::Module.table_query &.get_all([driver.id.not_nil!], index: :driver_id).update do
+        {"name" => driver.module_name}
       end
 
       Resource::Result::Success

--- a/src/placeos-core/mappings/driver_module_names.cr
+++ b/src/placeos-core/mappings/driver_module_names.cr
@@ -9,19 +9,19 @@ module PlaceOS::Core
       DriverModuleNames.update_module_names(driver)
     rescue exception
       Log.error(exception: exception) { {message: "while updating `module_name` for driver modules", name: driver.module_name} }
-      raise Resource::ProcessingError.new(mod.name, exception.message, cause: exception)
+      raise Resource::ProcessingError.new(driver.module_name, exception.message, cause: exception)
     end
 
     def self.update_module_names(
       driver : Model::Driver,
     )
       # Only consider `module_name` change events
-      return Resource::Result::Skipped unless driver.resolved_name_changed?
+      return Resource::Result::Skipped unless driver.module_name_changed?
 
       # Update the `module_name` field across all associated modules
       driver.modules.each do |mod|
         mod.update_fields(
-          module_name: driver.module_name,
+          name: driver.module_name,
         )
       end
 

--- a/src/placeos-core/mappings/module_names.cr
+++ b/src/placeos-core/mappings/module_names.cr
@@ -29,7 +29,7 @@ module PlaceOS::Core
     ) : Resource::Result
       module_id = mod.id.as(String)
       # Only consider name change events
-      return Resource::Result::Skipped unless mod.custom_name_changed?
+      return Resource::Result::Skipped unless mod.resolved_name_changed?
       # Only one core updates the mappings
       return Resource::Result::Skipped unless module_manager.discovery.own_node?(module_id)
 

--- a/src/placeos-core/mappings/module_names.cr
+++ b/src/placeos-core/mappings/module_names.cr
@@ -14,7 +14,7 @@ module PlaceOS::Core
       super()
     end
 
-    def process_resource(action : RethinkORM::Changefeed::Event, resource mod : PlaceOS::Model::Module) : Resource::Result
+    def process_resource(action : Resource::Action, resource mod : PlaceOS::Model::Module) : Resource::Result
       return Resource::Result::Skipped unless action.updated?
 
       ModuleNames.update_module_mapping(mod, module_manager)

--- a/src/placeos-core/resource_manager.cr
+++ b/src/placeos-core/resource_manager.cr
@@ -2,6 +2,7 @@ require "./cloning"
 require "./compilation"
 require "./mappings/control_system_modules"
 require "./mappings/module_names"
+require "./mappings/driver_module_names"
 
 # Sequences the acquisition and production of resources
 #
@@ -11,6 +12,7 @@ module PlaceOS::Core
     getter compilation : Compilation
     getter control_system_modules : Mappings::ControlSystemModules
     getter module_names : Mappings::ModuleNames
+    getter driver_module_names : Mappings::DriverModuleNames
     getter settings_updates : SettingsUpdate
     getter? started = false
 
@@ -28,6 +30,7 @@ module PlaceOS::Core
       @control_system_modules : Mappings::ControlSystemModules = Mappings::ControlSystemModules.new,
       @module_names : Mappings::ModuleNames = Mappings::ModuleNames.new,
       @settings_updates : SettingsUpdate = SettingsUpdate.new,
+      @driver_module_names : Mappings::DriverModuleNames = Mappings::DriverModuleNames.new,
       testing : Bool = false
     )
       @cloning = cloning || Cloning.new(testing: testing)
@@ -48,6 +51,9 @@ module PlaceOS::Core
 
         Log.info { "maintaining ControlSystem Module redis mappings" }
         control_system_modules.start
+
+        Log.info { "watching for Driver `module_name` changes" }
+        driver_module_names.start
 
         Log.info { "synchronising Module name changes with redis mappings" }
         module_names.start

--- a/src/placeos-core/settings_update.cr
+++ b/src/placeos-core/settings_update.cr
@@ -9,7 +9,7 @@ module PlaceOS
       super()
     end
 
-    def process_resource(action : RethinkORM::Changefeed::Event, resource settings : PlaceOS::Model::Settings) : Resource::Result
+    def process_resource(action : Resource::Action, resource settings : PlaceOS::Model::Settings) : Resource::Result
       # Ignore versions
       if settings.is_version?
         Log.debug { {message: "skipping settings version", settings_id: settings.id, parent_id: settings.settings_id} }


### PR DESCRIPTION
**Description of the change**

Updates the `name` of modules when `module_name` of a driver changes. 
Modules with a `custom_name` won't have their mappings effected, however their `name` field will still update. 

**Applicable issues**

- Closes #212 
